### PR TITLE
Add an option for turning off custom syntax highlighting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,6 +222,9 @@ Default values: ::
     " Set default pymode python other options
     let g:pymode_options_other = 1
 
+    " Enable pymode's custom syntax highlighting
+    let g:pymode_syntax = 1
+
 
 Default keys
 ============

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -75,6 +75,8 @@ PythonMode. These options should be set in your vimrc.
 
 |'pymode_utils_whitespaces'|        Remove unused whitespaces
 
+|'pymode_syntax'|                   Turns off the custom syntax highlighting
+
 |'pymode_options_indent'|           Set default pymode options for
                                   python indentation
 
@@ -232,6 +234,14 @@ Values: 0 or 1.
 Default: 1.
 
 Autoremove unused whitespaces
+
+------------------------------------------------------------------------------
+                                                               *'pymode_syntax'*
+Values: 0 or 1.
+Default: 1.
+
+If this option is set to 0 then the custom syntax highlighting will
+not be used.
 
 ------------------------------------------------------------------------------
                                                        *'pymode_options_indent'*

--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -3,9 +3,11 @@ if pymode#Default('b:pymode', 1)
 endif
 
 " Syntax highlight
-let python_highlight_all=1
-let python_highlight_exceptions=1
-let python_highlight_builtins=1
+if !pymode#Default('g:pymode_syntax', 1) || g:pymode_syntax
+    let python_highlight_all=1
+    let python_highlight_exceptions=1
+    let python_highlight_builtins=1
+endif
 
 " Python indent options
 if !pymode#Default('g:pymode_options_indent', 1) || g:pymode_options_indent

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -77,6 +77,8 @@ if version < 600
   syntax clear
 elseif exists("b:current_syntax")
   finish
+elseif exists("g:pymode_syntax") && g:pymode_syntax == 0
+  finish
 endif
 
 if exists("python_highlight_all") && python_highlight_all != 0


### PR DESCRIPTION
I like the existing highlighting, so I added an option to turn off the custom stuff in python-mode.
