### PR TITLE
Highlight self

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -247,6 +247,7 @@ if exists("python_highlight_builtin_objs") && python_highlight_builtin_objs != 0
   " Builtin objects and types
   syn keyword pythonBuiltinObj	True False Ellipsis None NotImplemented
   syn keyword pythonBuiltinObj	__debug__ __doc__ __file__ __name__ __package__
+  syn keyword pythonBuiltinObj self
 endif
 
 if exists("python_highlight_builtin_funcs") && python_highlight_builtin_funcs != 0


### PR DESCRIPTION
While self is not keyword, but a naming convention for a variable, I still like to see it highlighted.
