### PR TITLE
Override configuration with mandatory values

### DIFF
--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -88,9 +88,9 @@ linter = lint.PyLinter()
 pylint_re = re.compile('^[^:]+:(\d+): \[([EWRCI]+)[^\]]*\] (.*)$')
 
 checkers.initialize(linter)
+linter.load_file_configuration(vim.eval("g:pymode_lint_config"))
 linter.set_option("output-format", "parseable")
 linter.set_option("reports", 0)
-linter.load_file_configuration(vim.eval("g:pymode_lint_config"))
 
 # Pyflakes setup
 


### PR DESCRIPTION
Prevent the configuration from breaking python-mode.  The output-format
has to be 'parsable'.

Sooooo, awesome. Thanks a lot for python-mode.
