### PR TITLE
Add missing StringIO import to pymode#doc#Show

### DIFF
--- a/autoload/pymode/doc.vim
+++ b/autoload/pymode/doc.vim
@@ -5,6 +5,7 @@ fun! pymode#doc#Show(word) "{{{
     if a:word == ''
         echoerr "No name/symbol under cursor!"
     else
+        py import StringIO
         py sys.stdout, _ = StringIO.StringIO(), sys.stdout
         py help(vim.eval('a:word'))
         py sys.stdout, out = _, sys.stdout.getvalue()


### PR DESCRIPTION
Got "NameError: name 'StringIO' is not defined" on attempt to watch docs (on <K>)
Adding 'py import StringIO' fixed that issue.
