### PR TITLE
Fix an issue that default syntax file doesn't load when a g:pymode_syntax is true

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -4,7 +4,7 @@
 call pymode#Default('g:pymode_syntax', 1)
 
 " DESC: Disable script loading
-if pymode#Default('b:current_syntax', 'python') || !g:pymode_syntax
+if !g:pymode_syntax || pymode#Default('b:current_syntax', 'python')
     finish
 endif
 


### PR DESCRIPTION
I set the `let g:pymode_syntax = 0` in order to use default syntax in Vim.
However, not syntax highlighting all.
The cause that python-mode's syntax file is loaded before Vim's default syntax file 
and defined the `b:current_syntax` by python-mode's syntax file.
I fixed it.
