### PR TITLE
Fix empty pydoc window for "unnamed" clipboard

### DIFF
--- a/autoload/pymode/doc.vim
+++ b/autoload/pymode/doc.vim
@@ -13,7 +13,7 @@ fun! pymode#doc#Show(word) "{{{
         sil!py print out
         redi END
         call pymode#TempBuffer()
-        normal Pdd
+        normal ""Pdd
         wincmd p
     endif
 endfunction "}}}


### PR DESCRIPTION
Partial fix for issue 72 - https://github.com/klen/python-mode/issues/72

Relates to "unnamed" clipboard issue with pymode_run.
