### PR TITLE
Do not force `number` option if user prefers `relativenumber`

### DIFF
--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -28,7 +28,9 @@ endif
 if !pymode#Default('g:pymode_options_other', 1) || g:pymode_options_other
     setlocal complete+=t
     setlocal formatoptions-=t
-    setlocal number
+    if !&relativenumber
+        setlocal number
+    endif
     setlocal nowrap
     setlocal textwidth=79
 endif


### PR DESCRIPTION
This small patch checks if user prefers `relativenumber` Vim option before enforcing `setlocal number`
