### PR TITLE
Improve performance of white space removal

### DIFF
--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -135,7 +135,7 @@ endif
 if pymode#Option('utils_whitespaces')
     function PyModeTrimEndWhiteSpace()
         let cursor_pos = getpos('.')
-        %s/\s\+$//
+        :silent! %s/\s\+$//
         call setpos('.', cursor_pos)
     endfunction
     au BufWritePre <buffer> call PyModeTrimEndWhiteSpace()


### PR DESCRIPTION
On large'ish python files, this was taking 10+ seconds
at save time. Now it runs instantly, even on very large
python files.

Cursor position does not move.
