### PR TITLE
Use Include instead of PreCondit for imports.

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -21,12 +21,12 @@ call pymode#Default('g:pymode_syntax_all', 1)
     syn keyword pythonStatement	pass raise
     syn keyword pythonStatement	global assert
     syn keyword pythonStatement	lambda yield
-    syn keyword pythonStatement	with
+    syn keyword pythonStatement	with as
     syn keyword pythonStatement	def class nextgroup=pythonFunction skipwhite
     syn match   pythonFunction	"[a-zA-Z_][a-zA-Z0-9_]*" display contained
     syn keyword pythonRepeat	for while
     syn keyword pythonConditional	if elif else
-    syn keyword pythonPreCondit	import from as
+    syn keyword pythonInclude	import from
     syn keyword pythonException	try except finally
     syn keyword pythonOperator	and in is not or
 
@@ -240,7 +240,7 @@ endif
 " =============
 
     hi def link  pythonStatement    Statement
-    hi def link  pythonPreCondit    Statement
+    hi def link  pythonInclude      Include
     hi def link  pythonFunction	    Function
     hi def link  pythonConditional  Conditional
     hi def link  pythonRepeat       Repeat


### PR DESCRIPTION
Incidentally, this also fixes pyrex support, which depends on pythonInclude
existing.
