### PR TITLE
Initialize python-mode only when using python filetype

### DIFF
--- a/ftplugin/python/init-pymode.vim
+++ b/ftplugin/python/init-pymode.vim
@@ -1,3 +1,8 @@
+if exists('did_init_pymode_vim')
+    finish
+endif
+let did_init_pymode_vim = 1
+
 let g:pymode_version = "0.6.9"
 
 com! PymodeVersion echomsg "Current python-mode version: " . g:pymode_version
@@ -43,8 +48,7 @@ python << EOF
 import sys, vim, os
 
 curpath = vim.eval("getcwd()")
-libpath = os.path.join(os.path.dirname(os.path.dirname(
-    vim.eval("expand('<sfile>:p')"))), 'pylibs')
+libpath = os.path.join(vim.eval("expand('<sfile>:p:h:h:h')"), 'pylibs')
 
 sys.path = [os.path.dirname(libpath), libpath, curpath] + vim.eval("g:pymode_paths") + sys.path
 EOF

--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -1,3 +1,5 @@
+runtime ftplugin/python/init-pymode.vim
+
 if pymode#Default('b:pymode', 1)
     finish
 endif

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -1,4 +1,6 @@
 " vim: ft=vim:fdm=marker
+"
+runtime ftplugin/python/init-pymode.vim
 
 " DESC: Disable script loading
 if !pymode#Option('syntax') || pymode#Default('b:current_syntax', 'python')


### PR DESCRIPTION
As discussed in #121 python-mode loads quite some code everytime Vim is started, which is only needed for Python. This patch moves everything into the ftplugin so that initialization is only done the first time when a Python file is opened.
I quicly hacked this together, so it might be a little rough around the edges, but it seems to work.
