### PR TITLE
брать значение VIRTUAL_ENV из Vim, если не установлено в окружении

### DIFF
--- a/autoload/pymode/virtualenv.vim
+++ b/autoload/pymode/virtualenv.vim
@@ -15,7 +15,10 @@ fun! pymode#virtualenv#Activate() "{{{
 python << EOF
 import sys, vim, os
 
-ve_dir = os.environ['VIRTUAL_ENV']
+if 'VIRTUAL_ENV' in os.environ:
+    ve_dir = os.environ['VIRTUAL_ENV']
+else:
+    ve_dir = vim.eval('$VIRTUAL_ENV')
 ve_dir in sys.path or sys.path.insert(0, ve_dir)
 activate_this = os.path.join(os.path.join(ve_dir, 'bin'), 'activate_this.py')
 


### PR DESCRIPTION
Когда приходится работать с несколькими проектами со своим отдельным virtualenv получается не удобно прописывать путь в переменную окружения. Поэтому я прописываю ее в окружение Vim в настройках проекта:
<code>
let $VIRTUAL_ENV="/home/max/project/env"
</code>
и после делаю:
<code>
call pymode#virtualenv#Activate()
</code>

Предлагаемый патчик проверяет установлена ли переменная в окружении и если не установлена берет значение из Vim:
<code>
ve_dir = vim.eval('$VIRTUAL_ENV')
</code>
