### PR TITLE
Will only remove signs known from the previous quickfix list, if any.

### DIFF
--- a/autoload/pymode.vim
+++ b/autoload/pymode.vim
@@ -49,13 +49,18 @@ fun! pymode#QuickfixOpen(onlyRecognized, holdCursor, maxHeight, minHeight, jumpE
     endif
 endfunction "}}}
 
+fun! pymode#RemoveSigns() "{{{
+    if has('signs')
+        for item in filter(getqflist(), 'v:val.bufnr != ""')
+            execute printf('silent! sign unplace 1 buffer=%d', item.bufnr)
+        endfor
+    endif
+endfunction "}}}
 
 fun! pymode#PlaceSigns() "{{{
     " DESC: Place error signs
     "
     if has('signs')
-        sign unplace *
-
         if !pymode#Default("g:pymode_lint_signs_always_visible", 0) || g:pymode_lint_signs_always_visible
             call RopeShowSignsRulerIfNeeded()
         endif

--- a/autoload/pymode/lint.vim
+++ b/autoload/pymode/lint.vim
@@ -23,6 +23,10 @@ endfunction " }}}
 fun! pymode#lint#Parse()
     " DESC: Parse result of code checking.
     "
+    if g:pymode_lint_signs
+        call pymode#RemoveSigns()
+    endif
+
     call setqflist(g:qf_list, 'r')
 
     if g:pymode_lint_signs


### PR DESCRIPTION
Patched python-mode to only remove signs known from previous quickfix list. Fixes issue #185.
