### PR TITLE
Fix typo in option filtering, causing possible syntax error

### DIFF
--- a/pylibs/pymode/lint.py
+++ b/pylibs/pymode/lint.py
@@ -25,7 +25,7 @@ def check_file():
         s for s in (
             get_option('lint_select').split(',') +
             get_var('lint_select').split(','))
-        if i
+        if s
     ])
 
     buffer = get_current_buffer()


### PR DESCRIPTION
Hi,

This should fix issue #195, and probably others, too.

This also fixes an error where pymode_lint_ignore was not interpreted
correctly anymore.
