### PR TITLE
Use _get_encoding for encoding docstrings and messages

### DIFF
--- a/pylibs/ropevim.py
+++ b/pylibs/ropevim.py
@@ -379,8 +379,7 @@ class VimProgress(object):
 
 
 def echo(message):
-    if isinstance(message, unicode):
-        message = message.encode(vim.eval('&encoding'))
+    message = message.encode(VimUtils._get_encoding())
     print message
 
 
@@ -388,8 +387,7 @@ def status(message):
     if _rope_quiet:
         return
 
-    if isinstance(message, unicode):
-        message = message.encode(vim.eval('&encoding'))
+    message = message.encode(VimUtils._get_encoding())
     vim.command('redraw | echon "{0}"'.format(message))
 
 


### PR DESCRIPTION
- Fix for issue #211: 'Non-ascii characters in docstrings trigger unicode error'. Encode docstring with _get_encoding before reading it in.
- Use VimUtils._get_encoding for other instances of string encode in pylibs/ropevim.py
