### PR TITLE
Use pudb if available

### DIFF
--- a/ftplugin/python/init-pymode.vim
+++ b/ftplugin/python/init-pymode.vim
@@ -155,13 +155,18 @@ endif
 
 if !pymode#Default("g:pymode_breakpoint", 1) || g:pymode_breakpoint
 
-    if !pymode#Default("g:pymode_breakpoint_cmd", "import ipdb; ipdb.set_trace()  # XXX BREAKPOINT")  && has("python")
+    if !pymode#Default("g:pymode_breakpoint_cmd", "import pudb; pudb.set_trace()  # XXX BREAKPOINT")  && has("python")
 python << EOF
 from imp import find_module
 try:
-    find_module('ipdb')
+    find_module('pudb')
 except ImportError:
-    vim.command('let g:pymode_breakpoint_cmd = "import pdb; pdb.set_trace()  # XXX BREAKPOINT"')
+    try:
+        find_module('ipdb')
+    except ImportError:
+        vim.command('let g:pymode_breakpoint_cmd = "import pdb; pdb.set_trace()  # XXX BREAKPOINT"')
+    else:
+        vim.command('let g:pymode_breakpoint_cmd = "import ipdb; ipdb.set_trace()  # XXX BREAKPOINT"')
 EOF
     endif
 


### PR DESCRIPTION
I like to use [pudb](https://pypi.python.org/pypi/pudb) to debug python. This patch modifies the breakpoint shortcut to use pudb ahead of ipdb and pdb, if available.
