### PR TITLE
Remove trailing whitespace from README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ Default values: ::
     let g:pymode_lint_maxheight = 6
 
 
-.. note:: 
+.. note::
     Pylint options (ex. disable messages) may be defined in ``$HOME/pylint.rc``
     See pylint documentation: http://pylint-messages.wikidot.com/all-codes
 
@@ -511,7 +511,7 @@ License
 
 Licensed under a `GNU lesser general public license`_.
 
-If you like this plugin, you can send me postcard :) 
+If you like this plugin, you can send me postcard :)
 My address is here: "Russia, 143401, Krasnogorsk, Shkolnaya 1-19" to "Kirill Klenov".
 **Thanks for support!**
 

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -104,13 +104,13 @@ PythonMode. These options should be set in your vimrc.
 
 |'pymode_syntax_print_as_function'| Hightlight `print` as function
 
-|'pymode_syntax_highlight_equal_operator'| Hightlight `=` 
+|'pymode_syntax_highlight_equal_operator'| Hightlight `=`
 
-|'pymode_syntax_highlight_stars_operator'| Hightlight `*` 
+|'pymode_syntax_highlight_stars_operator'| Hightlight `*`
 
-|'pymode_syntax_highlight_self'|    Hightlight `self` 
+|'pymode_syntax_highlight_self'|    Hightlight `self`
 
-|'pymode_syntax_indent_errors'|     Hightlight indentation errors 
+|'pymode_syntax_indent_errors'|     Hightlight indentation errors
 
 |'pymode_syntax_space_errors'|      Hightlight trailing spaces as errors
 
@@ -152,7 +152,7 @@ To enable any of the options below you should put the given line in your
 2.2. Modeline ~
                                                       *PythonModeModeline*
 
-The VIM modeline `:help modeline` feature allows you to change pymode 
+The VIM modeline `:help modeline` feature allows you to change pymode
 options for the current file. Pymode modeline should always be the
 last line in the vimrc file and look like:
 
@@ -393,28 +393,28 @@ Hightlight `print` as function
 Values: 0 or 1.
 Default: |'pymode_syntax_all'|.
 
-Hightlight `=` 
+Hightlight `=`
 
 ------------------------------------------------------------------------------
                                       *'pymode_syntax_highlight_stars_operator'*
 Values: 0 or 1.
 Default: |'pymode_syntax_all'|.
 
-Hightlight `*` 
+Hightlight `*`
 
 ------------------------------------------------------------------------------
                                                  *'pymode_syntax_highlight_self'*
 Values: 0 or 1.
 Default: |'pymode_syntax_all'|.
 
-Hightlight `self` 
+Hightlight `self`
 
 ------------------------------------------------------------------------------
                                                  *'pymode_syntax_indent_errors'*
 Values: 0 or 1.
 Default: |'pymode_syntax_all'|.
 
-Hightlight indentation errors 
+Hightlight indentation errors
 
 ------------------------------------------------------------------------------
                                                   *'pymode_syntax_space_errors'*
@@ -576,7 +576,7 @@ iM                Operation with inner function or method.
 
 *:PyLintAuto*                                                         *PyLintAuto*
     Automatically fix PEP8 errors in the current buffer
-                                 
+
 *:Pyrun*                                                                   *Pyrun*
     Run current buffer
 
@@ -599,7 +599,7 @@ To work, rope_ creates a service directory: `.ropeproject`.  If
 |'pymode_rope_guess_project'| is set on (as it is by default) and
 `.ropeproject` is not found in the current dir, rope will scan for
 `.ropeproject` in every dir in the parent path.  If rope finds `.ropeproject`
-in parent dirs, rope sets projectis for all child dirs and the scan may be 
+in parent dirs, rope sets projectis for all child dirs and the scan may be
 slow for many dirs and files.
 
 Solutions:
@@ -621,7 +621,7 @@ modules if possible.  Try using pyflakes: see |'pymode_lint_checker'|.
 You may set |exrc| and |secure| in your |vimrc| to auto-set custom settings
 from `.vimrc` from your projects directories.
 >
-    Example: On Flask projects I automatically set 
+    Example: On Flask projects I automatically set
              'g:pymode_lint_checker = "pyflakes"'.
              On Django 'g:pymode_lint_checker = "pylint"'
 <
@@ -643,7 +643,7 @@ The sequence of commands that fixed this:
 
 ==============================================================================
 6. Credits ~
-                                                             *PythonModeCredits* 
+                                                             *PythonModeCredits*
     Kirill Klenov
         http://klen.github.com/
         http://github.com/klen/
@@ -684,7 +684,7 @@ The sequence of commands that fixed this:
 Python-mode is released under the GNU lesser general public license.
 See: http://www.gnu.org/copyleft/lesser.html
 
-If you like this plugin, you can send me a postcard :) 
+If you like this plugin, you can send me a postcard :)
 My address is: "Russia, 143401, Krasnogorsk, Shkolnaya 1-19" to "Kirill Klenov".
 Thanks for your support!
 

--- a/doc/ropevim.txt
+++ b/doc/ropevim.txt
@@ -151,7 +151,7 @@ those under ``ropetest`` folder.
 The find occurrences command ("<C-c> f" by default) can be used to
 find the occurrences of a python name.  If ``unsure`` option is
 ``yes``, it will also show unsure occurrences; unsure occurrences are
-indicated with a ``?`` mark in the end. 
+indicated with a ``?`` mark in the end.
 
         Note:
         That ropevim uses the quickfix feature of vim for
@@ -183,7 +183,7 @@ values you can use: >
   name2
    line3
 <
-Each line of the definition should start with a space or a tab. 
+Each line of the definition should start with a space or a tab.
     Note:
     That blank lines before the name of config definitions are ignored.
 
@@ -222,7 +222,7 @@ restructuring can be: >
                                                                  *RopeVariables*
 
 *'pymode_rope_codeassist_maxfixes'*     The maximum number of syntax errors
-                                  to fix for code assists. 
+                                  to fix for code assists.
                                   The default value is `1`.
 
 *'pymode_rope_local_prefix'*            The prefix for ropevim refactorings.


### PR DESCRIPTION
In my ‘.vimrc’ I have settings that highlight any trailing whitespace in red, so when do ‘:h python-mode’ I see all of the trailing whitespace.

Cheers,
Matt
