### PR TITLE
Fix loading of after/indent/python.vim

### DIFF
--- a/after/indent/python.vim
+++ b/after/indent/python.vim
@@ -1,8 +1,8 @@
-if pymode#Default('g:pymode', 1) || !g:pymode
+if !g:pymode
     finish
 endif
 
-if pymode#Default('b:pymode_indent', 1) || !g:pymode_indent
+if !g:pymode_indent
     finish
 endif
 


### PR DESCRIPTION
Hi,

Since python3 compatibility python indent is no more loaded correctly

This change fix it

Cheers and many thanks for this vim plugins,
