### PR TITLE
Fix error line numbers when a range is run

### DIFF
--- a/autoload/pymode/run.vim
+++ b/autoload/pymode/run.vim
@@ -113,6 +113,17 @@ EOF
         let &efm = s:efm
 
         cgetexpr(l:traceback)
+" If a range is run (starting other than at line 1), fix the reported error line numbers for
+" the current buffer
+        if a:line1 > 1
+            let qflist = getqflist()
+            for i in qflist
+                if i.bufnr == bufnr("")
+                    let i.lnum = i.lnum - 1 + a:line1
+                endif
+            endfor
+            call setqflist(qflist)
+        endif
 
         call pymode#QuickfixOpen(0, g:pymode_lint_hold, g:pymode_lint_maxheight, g:pymode_lint_minheight, 0)
         let &efm = l:_efm


### PR DESCRIPTION
If you run a range and there is an error, the quickfix window reports the line number of the range, not the line number of the file.  This patch fixes it.

Lawrence
