### PR TITLE
Make virtualenv.vim compatible with Python 3.

### DIFF
--- a/autoload/pymode/virtualenv.vim
+++ b/autoload/pymode/virtualenv.vim
@@ -23,7 +23,13 @@ activate_this = os.path.join(os.path.join(ve_dir, 'bin'), 'activate_this.py')
 if not os.path.exists(activate_this):
     activate_this = os.path.join(os.path.join(ve_dir, 'Scripts'), 'activate_this.py')
 
-execfile(activate_this, dict(__file__=activate_this))
+f = open(activate_this)
+try:
+    source = f.read()
+finally:
+    f.close()
+
+exec(compile(source, activate_this, 'exec'), dict(__file__=activate_this))
 EOF
 
     call pymode#WideMessage("Activate virtualenv: ".$VIRTUAL_ENV)


### PR DESCRIPTION
The `virtualenv.vim` file used the `execfile()` function to run the `activate_this.py` script from the active virtual environment. However, `execfile()` was removed in Python 3. This replaces the call to `execfile()` with a process that should be compatible with Python 2 and Python 3:
1. Read the script contents into a string.
2. Pass the string to `compile()` to get a compiled script object.
3. Pass the compiled script object to `exec()`.
