### PR TITLE
Fix dockstring in default_config due to H402 rule

### DIFF
--- a/pylibs/rope/base/default_config.py
+++ b/pylibs/rope/base/default_config.py
@@ -2,7 +2,7 @@
 
 
 def set_prefs(prefs):
-    """This function is called before opening the project"""
+    """This function is called before opening the project."""
 
     # Specify which files and folders to ignore in the project.
     # Changes to ignored resources are not added to the history and
@@ -81,5 +81,5 @@ def set_prefs(prefs):
 
 
 def project_opened(project):
-    """This function is called after opening the project"""
+    """This function is called after opening the project."""
     # Do whatever you like here!


### PR DESCRIPTION
When we run pep8 tests in a root project folder, flake8 with default
settings also checks .ropeproject/ folder and finds two errors there.

pep8 runtests: commands[0] | flake8
./.ropeproject/config.py:5:1: H402  one line docstring needs punctuation.
./.ropeproject/config.py:84:1: H402  one line docstring needs punctuation.

So I fixed these dockstrings to avoid such confusion
