### PR TITLE
Fixes #314

### DIFF
--- a/pylibs/pylama/config.py
+++ b/pylibs/pylama/config.py
@@ -37,7 +37,7 @@ def parse_options(
         async=_Default(async), format=_Default('pep8'),
         select=_Default(select), ignore=_Default(ignore),
         report=_Default(None), verbose=_Default(False),
-        linters=_Default(','.join(linters)), complexity=_Default(complexity),
+        linters=_Default(linters), complexity=_Default(complexity),
         options=_Default(options))
 
     if not (args is None):


### PR DESCRIPTION
I'm not really sure what else might happen but this works well (empty `g:pymode_lint_checker` uses all default ones, and selecting just a few with `g:pymode_lint_checker` also works). 
