### PR TITLE
Thread safety fix + lint_checker fix

### DIFF
--- a/pylibs/pymode/lint.py
+++ b/pylibs/pymode/lint.py
@@ -24,7 +24,7 @@ def check_file():
     rootpath = interface.eval_code('getcwd()')
 
     async = int(interface.get_option('lint_async'))
-    linters = interface.get_option('lint_checker')
+    linters = interface.get_option('lint_checker').split(',')
     ignore = interface.get_option('lint_ignore')
     select = interface.get_option('lint_select')
     complexity = interface.get_option('lint_mccabe_complexity') or '0'


### PR DESCRIPTION
Two fixes: one is an attempt to fix gvim crashing because vim receives an access from the wrong thread. Not 100% sure this is the fix, but I haven't had a problem yet, so we'll see.

The second fix fixes the ability to set lint_checker to only include the checkers you want.
