### PR TITLE
Real paths work allways, even when cwd != project root

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -151,7 +151,7 @@ def goto():
             return
 
         env.goto_file(
-            found_resource.path, cmd=ctx.options.get('goto_definition_cmd'))
+            found_resource.real_path, cmd=ctx.options.get('goto_definition_cmd'))
         env.goto_line(line)
 
 


### PR DESCRIPTION
Fixing the second problem mentioned at #345
