### PR TITLE
fix #385 (syntax highlighting failure)

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -78,7 +78,7 @@ endif
 
     syn keyword pythonStatement def nextgroup=pythonFunction skipwhite
     syn match pythonFunction "\%(\%(def\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars
-    syn region pythonVars start="(" end=")" contained contains=pythonParameters transparent keepend
+    syn region pythonVars start="(" skip=+\(".*"\|'.*'\)+ end=")" contained contains=pythonParameters transparent keepend
     syn match pythonParameters "[^,]*" contained contains=pythonParam skipwhite
     syn match pythonParam "[^,]*" contained contains=pythonExtraOperator,pythonLambdaExpr,pythonBuiltinObj,pythonBuiltinType,pythonConstant,pythonString,pythonNumber,pythonBrackets,pythonSelf skipwhite
     syn match pythonBrackets "{[(|)]}" contained skipwhite


### PR DESCRIPTION
Syntax highlight failure resolved by skipping everything between `'` or `"`.

Before this fix the code below had incorrect syntax highlighting.
![image](http://i.imgur.com/017h22W.png)
