### PR TITLE
fixed autoimport

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -362,7 +362,7 @@ class RopeContext(object):
         if os.path.exists("%s/__init__.py" % project_path):
             sys.path.append(project_path)
 
-        if self.options.get('autoimport'):
+        if self.options.get('autoimport') == '1':
             self.generate_autoimport_cache()
 
         env.debug('Context init', project_path)


### PR DESCRIPTION
in windows, gVim is displaying --multiprocessing-fork due to the option changed previously. Think it should be reverted back to the previous version
