### PR TITLE
Replace literal special chars in mappings.

### DIFF
--- a/after/ftplugin/python.vim
+++ b/after/ftplugin/python.vim
@@ -11,36 +11,36 @@ if g:pymode_motion
         finish
     endif
 
-    nnoremap <buffer> ]]  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', '')<CR>
-    nnoremap <buffer> [[  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', 'b')<CR>
-    nnoremap <buffer> ]C  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', '')<CR>
-    nnoremap <buffer> [C  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', 'b')<CR>
-    nnoremap <buffer> ]M  :<C-U>call pymode#motion#move('^\s*def\s', '')<CR>
-    nnoremap <buffer> [M  :<C-U>call pymode#motion#move('^\s*def\s', 'b')<CR>
+    nnoremap <buffer> ]]  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', '')<CR>
+    nnoremap <buffer> [[  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', 'b')<CR>
+    nnoremap <buffer> ]C  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', '')<CR>
+    nnoremap <buffer> [C  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', 'b')<CR>
+    nnoremap <buffer> ]M  :<C-U>call pymode#motion#move('^<Bslash>s*def<Bslash>s', '')<CR>
+    nnoremap <buffer> [M  :<C-U>call pymode#motion#move('^<Bslash>s*def<Bslash>s', 'b')<CR>
 
-    onoremap <buffer> ]]  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', '')<CR>
-    onoremap <buffer> [[  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', 'b')<CR>
-    onoremap <buffer> ]C  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', '')<CR>
-    onoremap <buffer> [C  :<C-U>call pymode#motion#move('^\(class\\|def\)\s', 'b')<CR>
-    onoremap <buffer> ]M  :<C-U>call pymode#motion#move('^\s*def\s', '')<CR>
-    onoremap <buffer> [M  :<C-U>call pymode#motion#move('^\s*def\s', 'b')<CR>
+    onoremap <buffer> ]]  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', '')<CR>
+    onoremap <buffer> [[  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', 'b')<CR>
+    onoremap <buffer> ]C  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', '')<CR>
+    onoremap <buffer> [C  :<C-U>call pymode#motion#move('<Bslash>v^(class<bar>def)<Bslash>s', 'b')<CR>
+    onoremap <buffer> ]M  :<C-U>call pymode#motion#move('^<Bslash>s*def<Bslash>s', '')<CR>
+    onoremap <buffer> [M  :<C-U>call pymode#motion#move('^<Bslash>s*def<Bslash>s', 'b')<CR>
 
-    vnoremap <buffer> ]]  :call pymode#motion#vmove('^\(class\\|def\)\s', '')<CR>
-    vnoremap <buffer> [[  :call pymode#motion#vmove('^\(class\\|def\)\s', 'b')<CR>
-    vnoremap <buffer> ]M  :call pymode#motion#vmove('^\s*def\s', '')<CR>
-    vnoremap <buffer> [M  :call pymode#motion#vmove('^\s*def\s', 'b')<CR>
+    vnoremap <buffer> ]]  :call pymode#motion#vmove('<Bslash>v^(class<bar>def)<Bslash>s', '')<CR>
+    vnoremap <buffer> [[  :call pymode#motion#vmove('<Bslash>v^(class<bar>def)<Bslash>s', 'b')<CR>
+    vnoremap <buffer> ]M  :call pymode#motion#vmove('^<Bslash>s*def<Bslash>s', '')<CR>
+    vnoremap <buffer> [M  :call pymode#motion#vmove('^<Bslash>s*def<Bslash>s', 'b')<CR>
 
-    onoremap <buffer> C  :<C-U>call pymode#motion#select('^\s*class\s', 0)<CR>
-    onoremap <buffer> aC :<C-U>call pymode#motion#select('^\s*class\s', 0)<CR>
-    onoremap <buffer> iC :<C-U>call pymode#motion#select('^\s*class\s', 1)<CR>
-    vnoremap <buffer> aC :<C-U>call pymode#motion#select('^\s*class\s', 0)<CR>
-    vnoremap <buffer> iC :<C-U>call pymode#motion#select('^\s*class\s', 1)<CR>
+    onoremap <buffer> C  :<C-U>call pymode#motion#select('^<Bslash>s*class<Bslash>s', 0)<CR>
+    onoremap <buffer> aC :<C-U>call pymode#motion#select('^<Bslash>s*class<Bslash>s', 0)<CR>
+    onoremap <buffer> iC :<C-U>call pymode#motion#select('^<Bslash>s*class<Bslash>s', 1)<CR>
+    vnoremap <buffer> aC :<C-U>call pymode#motion#select('^<Bslash>s*class<Bslash>s', 0)<CR>
+    vnoremap <buffer> iC :<C-U>call pymode#motion#select('^<Bslash>s*class<Bslash>s', 1)<CR>
 
-    onoremap <buffer> M  :<C-U>call pymode#motion#select('^\s*def\s', 0)<CR>
-    onoremap <buffer> aM :<C-U>call pymode#motion#select('^\s*def\s', 0)<CR>
-    onoremap <buffer> iM :<C-U>call pymode#motion#select('^\s*def\s', 1)<CR>
-    vnoremap <buffer> aM :<C-U>call pymode#motion#select('^\s*def\s', 0)<CR>
-    vnoremap <buffer> iM :<C-U>call pymode#motion#select('^\s*def\s', 1)<CR>
+    onoremap <buffer> M  :<C-U>call pymode#motion#select('^<Bslash>s*def<Bslash>s', 0)<CR>
+    onoremap <buffer> aM :<C-U>call pymode#motion#select('^<Bslash>s*def<Bslash>s', 0)<CR>
+    onoremap <buffer> iM :<C-U>call pymode#motion#select('^<Bslash>s*def<Bslash>s', 1)<CR>
+    vnoremap <buffer> aM :<C-U>call pymode#motion#select('^<Bslash>s*def<Bslash>s', 0)<CR>
+    vnoremap <buffer> iM :<C-U>call pymode#motion#select('^<Bslash>s*def<Bslash>s', 1)<CR>
 
 endif
 


### PR DESCRIPTION
Replaces \ with <Bslash>, which makes mappings work for those having
cpoptions-=B.

Also replaces | with <bar> to clean up the ugly double-escape.

Fixes #430.
