### PR TITLE
Added options to give more control over rope paths

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,6 +4,11 @@ Changelog
     * Get fold's expression symbol from &fillchars;
     * Fixed error when setting g:pymode_breakpoint_cmd (expobrain);
     * Fixed code running;
+    * Ability to override rope project root and .ropeproject folder
+    * Added path argument to `PymodeRopeNewProject` which skips prompt
+
+    * Options added:
+        'pymode_rope_project_root', 'pymode_rope_ropefolder'
 
 
 ## 2013-12-04 0.7.8b

--- a/autoload/pymode/rope.vim
+++ b/autoload/pymode/rope.vim
@@ -83,7 +83,7 @@ fun! pymode#rope#regenerate() "{{{
 endfunction "}}}
 
 
-fun! pymode#rope#new() "{{{
+fun! pymode#rope#new(...) "{{{
     PymodePython rope.new()
 endfunction "}}}
 

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -354,7 +354,7 @@ Turn on the rope script                                        *'g:pymode_rope'*
 .ropeproject Folder ~
                                                                   *.ropeproject*
 
-*:PymodeRopeNewProject* -- Open new Rope project in current working directory
+*:PymodeRopeNewProject* [<path>] -- Open new Rope project in the given path
 *:PymodeRopeRegenerate* -- Regenerate the project cache
 
 Rope uses a folder inside projects for holding project configuration and data.
@@ -371,8 +371,9 @@ Currently it is used for things such as:
 * It can be used to save information about object inferences.
 * It can be used to save a global name cache, which is used for auto-import.
 
-If `.ropeproject` is not found in the current directory, rope will look
-recursively for it in parent folders.
+By default, if `.ropeproject` is not found in the current directory, rope will
+look recursively for it in parent folders.
+
 Warning: If rope finds `.ropeproject` in a parent dir, it will use it with
 all its child directories, which may slow scanning down (because of many,
 possibly unrelated, files)
@@ -381,6 +382,23 @@ Enable searching for |.ropeproject| in parent directories
                                                   *'g:pymode_rope_lookup_project'*
 >
     let g:pymode_rope_lookup_project = 1
+
+You can also manually set the rope project directory. If not specified rope will
+use the current directory.
+                                                  *'g:pymode_rope_project_root'*
+>
+    let g:pymode_rope_project_root = ""
+
+
+The location of the `.ropeproject` folder may also be overridden if you wish to
+keep it outside of your project root. The rope library treats this folder as a
+project resource, so the path will always be relative to your proejct root (a
+leading '/' will be ignored). You may use `'..'` path segments to place the
+folder outside of your project root.
+                                                 *'g:pymode_rope_ropefolder'*
+>
+    let g:pymode_rope_ropefolder='.ropeproject'
+
 
 
 Show documentation for element under cursor ~
@@ -645,6 +663,10 @@ Solutions:
   current dir.
 - Set |'g:pymode_rope_lookup_project'| to 0 for prevent searching in parent
   dirs.
+
+You may also set |'g:pymode_rope_project_root'| to manually specify the project
+root path.
+
 
 
 Pylint check is very slow

--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -177,7 +177,7 @@ if g:pymode_rope
         inoremap <silent> <buffer> . .<C-R>=pymode#rope#complete_on_dot()<CR>
     end
 
-    command! -buffer PymodeRopeNewProject call pymode#rope#new()
+    command! -buffer -nargs=? PymodeRopeNewProject call pymode#rope#new(<f-args>)
     command! -buffer PymodeRopeUndo call pymode#rope#undo()
     command! -buffer PymodeRopeRedo call pymode#rope#redo()
     command! -buffer PymodeRopeRenameModule call pymode#rope#rename_module()

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -151,6 +151,12 @@ call pymode#default('g:pymode_rope', 1)
 " System plugin variable
 call pymode#default('g:pymode_rope_current', '')
 
+" Configurable rope project root
+call pymode#default('g:pymode_rope_project_root', '')
+
+" Configurable rope project folder (always relative to project root)
+call pymode#default('g:pymode_rope_ropefolder', '.ropeproject') 
+
 " If project hasnt been finded in current working directory, look at parents directory
 call pymode#default('g:pymode_rope_lookup_project', 1)
 


### PR DESCRIPTION
```
* Ability to override rope project root and .ropeproject folder
* Added path argument to `PymodeRopeNewProject` which skips prompt

* Options added:
    'pymode_rope_project_root', 'pymode_rope_ropefolder'
```
