### PR TITLE
Fix Vim hanging on buffer write (any filetype!) on Windows

### DIFF
--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -1,4 +1,4 @@
-" vi: fdl=1 
+" vi: fdl=1
 let g:pymode_version = "0.8.1"
 
 com! PymodeVersion echomsg "Current python-mode version: " . g:pymode_version
@@ -155,7 +155,7 @@ call pymode#default('g:pymode_rope_current', '')
 call pymode#default('g:pymode_rope_project_root', '')
 
 " Configurable rope project folder (always relative to project root)
-call pymode#default('g:pymode_rope_ropefolder', '.ropeproject') 
+call pymode#default('g:pymode_rope_ropefolder', '.ropeproject')
 
 " If project hasnt been finded in current working directory, look at parents directory
 call pymode#default('g:pymode_rope_lookup_project', 0)
@@ -246,10 +246,6 @@ if &compatible
     set nocompatible
 endif
 filetype plugin on
-
-if exists('+shellslash')
-    set shellslash
-endif
 
 " Disable python-related functionality
 " let g:pymode_python = 'disable'


### PR DESCRIPTION
I recently update python-mode and I could not work with Vim anymore. I'm on Windows7 64 bits. Setting the shellslash makes any buffer write (python file or not) to hang forever!

I don't know if this is the real fix but it does it for me. I have not noticed other problems.
