### PR TITLE
Revise readme to guide users customize key bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Install with commands:
      apt-get update
      apt-get install vim-python-mode
 
-If you are getting the message: "The following signatures couldn' be verified because the public key is not available": ::
+If you are getting the message: "The following signatures couldn't be verified because the public key is not available": ::
 
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B5DF65307000E266
 
@@ -126,7 +126,7 @@ If your python-mode doesn't work:
 
     vim -u <path_to_pymode>/debug.vim
 
-And try to repeat your case. If no error occurs, seems like problem isnt in the
+And try to repeat your case. If no error occurs, seems like problem isn't in the
 plugin.
 
 2. Type `:PymodeTroubleshooting`
@@ -134,6 +134,21 @@ plugin.
 And fix any warnings or copy the output and send it to me. (For example, by
 creating a `new github issue <https://github.com/klen/python-mode/issues/new>`_
 if one does not already exist for the problem).
+
+
+Customization
+=============
+
+You can override the default key bindings by redefining them in your `.vimrc`, for example: ::
+
+    " Override go-to.definition key shortcut to Ctrl-]
+    let g:pymode_rope_goto_definition_bind = "<C-]>"
+
+    " Override run current python file key shortcut to Ctrl-Shift-e
+    let g:pymode_run_bind = "<C-S-e>"
+
+    " Override view python doc key shortcut to Ctrl-Shift-d
+    let g:pymode_doc_bind = "<C-S-d>"
 
 
 Documentation


### PR DESCRIPTION
This is a humble pull request, to give users a quick customization information, otherwise for people who have key conflicts with `<leader>r`, `<C-c>g`, etc, will be able to quickly customize the shortcuts themselves.

Take me as an example, I used <leader>r to do selected string replacement, by having the following contents in my `vimrc`:

```
function! CmdLine(str)
    exe "menu Foo.Bar :" . a:str
    emenu Foo.Bar
    unmenu Foo
endfunction

function! VisualSelection(direction) range
    let l:saved_reg = @"
    execute "normal! vgvy"

    let l:pattern = escape(@", '\\/.*$^~[]')
    let l:pattern = substitute(l:pattern, "\n$", "", "")

    if a:direction == 'b'
        execute "normal ?" . l:pattern . "^M"
    elseif a:direction == 'gv'
        call CmdLine("vimrep " . '/'. l:pattern . '/' . ' **/*.')
    elseif a:direction == 'replace'
        call CmdLine("%s" . '/'. l:pattern . '/')
    elseif a:direction == 'f'
        execute "normal /" . l:pattern . "^M"
    endif

    let @/ = l:pattern
    let @" = l:saved_reg
endfunction

" Visual mode pressing * or # searches for the current selection
" Super useful! From an idea by Michael Naumann
vnoremap <silent> * :call VisualSelection('f')<CR>
vnoremap <silent> # :call VisualSelection('b')<CR>
" When I press <leader>r I can search and replace the selected text
vnoremap <silent> <leader>r :call VisualSelection('replace')<CR>
```

I read the source code and found default key shortcuts definition is located in:  `python-mode/plugin/pymode.vim`, then I managed to override the default key bindings, this is indeed less convenient for users like me, thus I enhanced the readme.rst to include Customization information, please consider approve my pull request, thank you and appreciate your great work for this awesome plugin:)

BTW, I fixed few typos as well.
