### PR TITLE
add class hierarchy support to rename

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -465,15 +465,19 @@ class Refactoring(object): # noqa
                 if not input_str:
                     return False
 
-                changes = self.get_changes(refactor, input_str)
-
                 action = env.user_input_choices(
-                    'Choose what to do:', 'perform', 'preview')
+                    'Choose what to do:', 'perform', 'preview',
+                        'perform in class hierarchy',
+                        'preview in class hierarchy')
+
+                in_hierarchy = action.endswith("in class hierarchy")
+
+                changes = self.get_changes(refactor, input_str, in_hierarchy)
 
                 if not action:
                     return False
 
-                if action == 'preview':
+                if action.startswith('preview'):
                     print("\n   ")
                     print("-------------------------------")
                     print("\n%s\n" % changes.get_description())
@@ -505,7 +509,7 @@ class Refactoring(object): # noqa
         return True
 
     @staticmethod
-    def get_changes(refactor, input_str):
+    def get_changes(refactor, input_str, in_hierarchy=False):
         """ Get changes.
 
         :return Changes:
@@ -513,7 +517,7 @@ class Refactoring(object): # noqa
         """
         progress = ProgressHandler('Calculate changes ...')
         return refactor.get_changes(
-            input_str, task_handle=progress.handle)
+            input_str, task_handle=progress.handle, in_hierarchy = in_hierarchy)
 
 
 class RenameRefactoring(Refactoring):


### PR DESCRIPTION
When a method is renamed, the user can choose "perform in class
hierarchy". This will rename methods of the same name in super-
and subclasses. For example, in the following

  class A(object):
    def foo(self): pass

  class A2(A):
    def foo(self): pass

  class B(object):
    def foo(self): pass

A normal rename in A2's foo will not rename A's foo and vice versa.
With the "in class hierarchy" mode, both will be renamed. In both
cases, class B will not be altered, as it isn't a super- or subclass.

Fixes #456
