### PR TITLE
Exclude auto generated vim doc tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test.py
 todo.txt
 vendor
 vim.py
+doc/tags


### PR DESCRIPTION
Simple little addition to .gitignore to exclude the auto generated vim doc tags.
