### PR TITLE
Replace getcurpos with getpos to support older Vim

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -79,7 +79,7 @@ fun! pymode#folding#expr(lnum) "{{{
     " Handle nested defs but only for files shorter than
     " g:pymode_folding_nest_limit lines due to performance concerns
     if line('$') < g:pymode_folding_nest_limit && indent(prevnonblank(a:lnum))
-        let curpos = getcurpos()
+        let curpos = getpos('.')
         try
             let last_block = s:BlockStart(a:lnum)
             let last_block_indent = indent(last_block)


### PR DESCRIPTION
`getcurpos()` wasn't added until 7.4.313 and using it in a fold expression causes silent errors. I replaced it with `getpos('.')` which is no different for this application. This pull request will resolve #503.
