### PR TITLE
Revert "Switch to loclist"

### DIFF
--- a/autoload/pymode.vim
+++ b/autoload/pymode.vim
@@ -110,17 +110,13 @@ fun! pymode#buffer_pre_write() "{{{
 endfunction
 
 fun! pymode#buffer_post_write() "{{{
-    if g:pymode_rope
-        if b:pymode_modified && g:pymode_rope_regenerate_on_write
-            call pymode#debug('regenerate')
-            call pymode#rope#regenerate()
-        endif
+    if b:pymode_modified && g:pymode_rope_regenerate_on_write
+        call pymode#debug('regenerate')
+        call pymode#rope#regenerate()
     endif
-    if g:pymode_lint
-        if g:pymode_lint_unmodified || (g:pymode_lint_on_write && b:pymode_modified)
-            call pymode#debug('check code')
-            call pymode#lint#check()
-        endif
+    if g:pymode_lint_unmodified || (g:pymode_lint_on_write && b:pymode_modified)
+        call pymode#debug('check code')
+        call pymode#lint#check()
     endif
 endfunction "}}}
 

--- a/autoload/pymode/lint.vim
+++ b/autoload/pymode/lint.vim
@@ -66,7 +66,8 @@ fun! pymode#lint#check() "{{{
     call g:PymodeSigns.refresh(loclist)
 
     if g:pymode_lint_cwindow
-        call loclist.show()
+        call setqflist(loclist._loclist)
+        call pymode#quickfix_open(0, g:pymode_quickfix_maxheight, g:pymode_quickfix_minheight, 0)
     endif
 
     call pymode#lint#show_errormessage()

--- a/autoload/pymode/rope.vim
+++ b/autoload/pymode/rope.vim
@@ -2,8 +2,6 @@
 "
 PymodePython from pymode import rope
 
-call pymode#tools#loclist#init()
-
 
 fun! pymode#rope#completions(findstart, base)
     PymodePython rope.completions()
@@ -57,7 +55,11 @@ fun! pymode#rope#find_it()
     let loclist._title = "Occurrences"
     call pymode#wide_message('Finding Occurrences ...')
     PymodePython rope.find_it()
-    call loclist.show()
+    call pymode#wide_message('')
+    if !empty(l:output)
+        call setqflist(l:output)
+        call pymode#quickfix_open(0, g:pymode_quickfix_maxheight, g:pymode_quickfix_minheight, 0)
+    end
 endfunction
 
 

--- a/autoload/pymode/run.vim
+++ b/autoload/pymode/run.vim
@@ -43,8 +43,6 @@ let s:efm .= '%-G%.%#'
 
 PymodePython from pymode.run import run_code
 
-call pymode#tools#loclist#init()
-
 
 " DESC: Run python code
 fun! pymode#run#code_run(line1, line2) "{{{
@@ -88,11 +86,7 @@ fun! pymode#run#code_run(line1, line2) "{{{
             call setqflist(qflist)
         endif
 
-        let loclist = g:PymodeLocList.current()
-        let loclist._loclist = getqflist()
-        let loclist._title = "Run errors"
-        call loclist.show()
-
+        call pymode#quickfix_open(0, g:pymode_quickfix_maxheight, g:pymode_quickfix_maxheight, 0)
         let &efm = l:_efm
 
     catch /E234/

--- a/autoload/pymode/tools/loclist.vim
+++ b/autoload/pymode/tools/loclist.vim
@@ -10,7 +10,6 @@ fun! g:PymodeLocList.init(raw_list) "{{{
     let obj = copy(self)
     let loc_list = filter(copy(a:raw_list), 'v:val["valid"] == 1')
     call obj.clear()
-    let obj._title = 'CodeCheck'
     return obj
 endfunction "}}}
 
@@ -19,6 +18,7 @@ fun! g:PymodeLocList.current() "{{{
     if !exists("b:pymode_loclist")
         let b:pymode_loclist = g:PymodeLocList.init([])
     endif
+    let b:pymode_loclist._bufnr = bufnr('.')
     return b:pymode_loclist
 endfunction "}}}
 
@@ -31,7 +31,7 @@ endfunction "}}}
 fun! g:PymodeLocList.clear() "{{{
     let self._loclist = []
     let self._messages = {}
-    let self._name = expand('%:t')
+    let self._bufnr = bufnr('')
 endfunction "}}}
 
 
@@ -61,21 +61,4 @@ fun! g:PymodeLocList.filter(filters) "{{{
 
     endfor
     return loclist
-endfunction "}}}
-
-
-fun! g:PymodeLocList.show() "{{{
-    call setloclist(0, self._loclist)
-    if self.is_empty()
-        lclose
-    else
-        let num = winnr()
-        lopen
-        setl nowrap
-        execute max([min([line("$"), g:pymode_quickfix_maxheight]), g:pymode_quickfix_minheight]) . "wincmd _"
-        if num != winnr()
-            call setwinvar(winnr(), 'quickfix_title', self._title . ' <' . self._name . '>')
-            exe num . "wincmd w"
-        endif
-    end
 endfunction "}}}


### PR DESCRIPTION
In order to resolve issue: https://github.com/klen/python-mode/issues/540 the commit for going towards LocList instead of using quickfix was reverted.

This reverts commit cf8ddc70650a850edfce1e9408874e9f037966b7.

Conflicts:
    autoload/pymode/rope.vim
    autoload/pymode/tools/loclist.vim
