### PR TITLE
add g:pymode_indent_hanging_paren option

### DIFF
--- a/autoload/pymode/indent.vim
+++ b/autoload/pymode/indent.vim
@@ -21,7 +21,7 @@ function! pymode#indent#get_indent(lnum)
         let parcol = col('.')
         let closing_paren = match(getline(a:lnum), '^\s*[])}]') != -1
         if match(getline(parlnum), '[([{]\s*$', parcol - 1) != -1
-            if closing_paren
+            if closing_paren && !g:pymode_indent_hanging_paren
                 return indent(parlnum)
             else
                 return indent(parlnum) + &shiftwidth

--- a/autoload/pymode/troubleshooting.vim
+++ b/autoload/pymode/troubleshooting.vim
@@ -64,6 +64,7 @@ EOF
     call append('$', 'let pymode_doc_bind = ' . string(g:pymode_doc_bind))
     call append('$', 'let pymode_folding = ' . string(g:pymode_folding))
     call append('$', 'let pymode_indent = ' . string(g:pymode_indent))
+    call append('$', 'let pymode_indent_hanging_paren = ' . string(g:pymode_indent_hanging_paren))
     call append('$', 'let pymode_lint = ' . string(g:pymode_lint))
     call append('$', 'let pymode_lint_checkers = ' . string(g:pymode_lint_checkers))
     call append('$', 'let pymode_lint_cwindow = ' . string(g:pymode_lint_cwindow))

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -152,6 +152,16 @@ Enable pymode indentation                                  *'g:pymode_indent'*
 >
     let g:pymode_indent = 1
 
+Enable hanging indent for closing             *'g:pymode_indent_hanging_paren'*
+braces, brackets, and parentheses
+
+When enabled, the closing brace/bracket/parenthesis of a multi-line construct
+will be indented to the first non-whitespace character of the previous line.
+When disabled, they will line up under the first character of the line that
+starts the multi-line construct. (Default: disabled)
+
+    let g:pymode_indent_hanging_paren = 0
+
 ------------------------------------------------------------------------------
 2.3 Python folding ~
                                                                 *pymode-folding*

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -33,6 +33,9 @@ call pymode#default('g:pymode_doc_bind', 'K')
 
 " Enable/Disable pymode PEP8 indentation
 call pymode#default("g:pymode_indent", 1)
+" Enable/Disable closing parens, braces, brackets at same indent level
+" as previous line
+call pymode#default("g:pymode_indent_hanging_paren", 0)
 
 " Enable/disable pymode folding for pyfiles.
 call pymode#default("g:pymode_folding", 1)


### PR DESCRIPTION
PEP8 states:

```
The closing brace/bracket/parenthesis on multi-line constructs may
either line up under the first non-whitespace character of the last line
of list, as in:

my_list = [
    1, 2, 3,
    4, 5, 6,
    ]
result = some_function_that_takes_arguments(
    'a', 'b', 'c',
    'd', 'e', 'f',
    )

or it may be lined up under the first character of the line that starts
the multi-line construct, as in:

my_list = [
    1, 2, 3,
    4, 5, 6,
]
result = some_function_that_takes_arguments(
    'a', 'b', 'c',
    'd', 'e', 'f',
)
```

Add a `g:pymode_indent_hanging_paren` option that switches between the
two styles.

When enabled, the closing brace/bracket/parenthesis will be indented to
the first non-whitespace character of the previous line.  When disabled,
they will line up under the first character of the line that starts the
multi-line construct.

By default, this option is disabled to match historical behavior.
