### PR TITLE
Conflict between pymode folding and vim diff

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -11,9 +11,25 @@ let s:symbol = matchstr(&fillchars, 'fold:\zs.')  " handles multibyte characters
 if s:symbol == ''
     let s:symbol = ' '
 endif
+let foldtextprev=foldtext()
 
+fun! pymode#folding#enable() " {{{
+    setlocal foldmethod=expr
+    setlocal foldexpr=pymode#folding#expr(v:lnum)
+    setlocal foldtext=pymode#folding#text()
+endfunction "}}}
+
+fun! pymode#folding#disable() " {{{
+    " setlocal foldmethod=expr
+    setlocal foldexpr="0"
+    setlocal foldtext=&foldtextprev
+endfunction "}}}
 
 fun! pymode#folding#text() " {{{
+    if &diff
+        call pymode#folding#disable()
+        return
+    endif
     let fs = v:foldstart
     while getline(fs) !~ s:def_regex && getline(fs) !~ s:doc_begin_regex
         let fs = nextnonblank(fs + 1)
@@ -40,6 +56,9 @@ endfunction "}}}
 
 
 fun! pymode#folding#expr(lnum) "{{{
+    if &diff
+        pymode#folding#disable()
+    endif
 
     let line = getline(a:lnum)
     let indent = indent(a:lnum)

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -435,7 +435,7 @@ use the current directory.
 
 The location of the `.ropeproject` folder may also be overridden if you wish to
 keep it outside of your project root. The rope library treats this folder as a
-project resource, so the path will always be relative to your proejct root (a
+project resource, so the path will always be relative to your project root (a
 leading '/' will be ignored). You may use `'..'` path segments to place the
 folder outside of your project root.
                                                  *'g:pymode_rope_ropefolder'*

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -486,7 +486,7 @@ imported) from project                              *'g:pymode_rope_autoimport'*
 
 Load modules to autoimport by default       *'g:pymode_rope_autoimport_modules'*
 >
-    let g:pymode_rope_autoimport_modules = ['os', 'shutil', 'datetime'])
+    let g:pymode_rope_autoimport_modules = ['os', 'shutil', 'datetime']
 
 Offer to unresolved import object after completion.
 >

--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -55,9 +55,10 @@ endif
 " Python folding
 if g:pymode_folding
 
-    setlocal foldmethod=expr
-    setlocal foldexpr=pymode#folding#expr(v:lnum)
-    setlocal foldtext=pymode#folding#text()
+    " setlocal foldmethod=expr
+    " setlocal foldexpr=pymode#folding#expr(v:lnum)
+    " setlocal foldtext=pymode#folding#text()
+    call pymode#folding#enable()
 
 endif
 

--- a/pymode/lint.py
+++ b/pymode/lint.py
@@ -4,6 +4,7 @@ from .environment import env
 from .utils import silence_stderr
 
 import os.path
+import vim
 
 
 from pylama.lint.extensions import LINTERS
@@ -37,6 +38,9 @@ def code_check():
             ignore=env.var('g:pymode_lint_ignore'),
             select=env.var('g:pymode_lint_select'),
         )
+        linters_keys = [l[0] for l in options.linters]
+        if vim.current.buffer.options['modified'] and 'pylint' in linters_keys:
+            del options.linters[linters_keys.index('pylint')]
 
         for linter in linters:
             opts = env.var('g:pymode_lint_options_%s' % linter, silence=True)

--- a/t/lint.vim
+++ b/t/lint.vim
@@ -1,4 +1,4 @@
-source  plugin/pymode.vim 
+source  plugin/pymode.vim
 
 describe 'pymode check code'
 
@@ -15,7 +15,7 @@ describe 'pymode check code'
     end
 
     it 'lint new'
-        put =['# coding: utf-8', 'call_unknown_function()']
+        put =['# coding: utf-8', 'x = 1']
         PymodeLint
         Expect getloclist(0) ==  []
     end
@@ -23,8 +23,21 @@ describe 'pymode check code'
     it 'lint code'
         e t/test.py
         PymodeLint
-        Expect getloclist(0) ==  [{'lnum': 6, 'bufnr': 1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'pattern': '', 'text': 'W0612 local variable "unused" is assigned to but never used [pyflakes]'}, {'lnum': 8, 'bufnr': 1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'pattern': '', 'text': 'E0602 undefined name "unknown" [pyflakes]'}]
+        let ll = getloclist(0)
+
+        Expect len(ll) == 2
+
+        Expect ll[0]['lnum'] == 6
+        Expect ll[0]['col'] == 7
+        Expect ll[0]['type'] == 'C'
+        Expect ll[0]['valid'] == 1
+        Expect ll[0]['text'] == 'E225 missing whitespace around operator [pep8]'
+
+        Expect ll[1]['lnum'] == 9
+        Expect ll[1]['col'] == 1
+        Expect ll[1]['type'] == 'E'
+        Expect ll[1]['valid'] == 1
+        Expect ll[1]['text'] == "E0602 undefined name 'unknown' [pyflakes]"
     end
 
 end
-

--- a/t/lint.vim
+++ b/t/lint.vim
@@ -25,19 +25,31 @@ describe 'pymode check code'
         PymodeLint
         let ll = getloclist(0)
 
-        Expect len(ll) == 2
+        Expect len(ll) == 4
 
-        Expect ll[0]['lnum'] == 6
-        Expect ll[0]['col'] == 7
-        Expect ll[0]['type'] == 'C'
+        Expect ll[0]['lnum'] == 1
+        Expect ll[0]['col'] == 0
         Expect ll[0]['valid'] == 1
-        Expect ll[0]['text'] == 'E225 missing whitespace around operator [pep8]'
+        Expect ll[0]['type'] == 'C'
+        Expect ll[0]['text'] == "C0111 Missing module docstring [pylint]"
 
-        Expect ll[1]['lnum'] == 9
-        Expect ll[1]['col'] == 1
-        Expect ll[1]['type'] == 'E'
+        Expect ll[1]['lnum'] == 5
+        Expect ll[1]['col'] == 0
         Expect ll[1]['valid'] == 1
-        Expect ll[1]['text'] == "E0602 undefined name 'unknown' [pyflakes]"
+        Expect ll[1]['type'] == 'C'
+        Expect ll[1]['text'] == "C0111 Missing function docstring [pylint]"
+
+        Expect ll[2]['lnum'] == 6
+        Expect ll[2]['col'] == 7
+        Expect ll[2]['valid'] == 1
+        Expect ll[2]['type'] == 'C'
+        Expect ll[2]['text'] == "E225 missing whitespace around operator [pep8]"
+
+        Expect ll[3]['lnum'] == 9
+        Expect ll[3]['col'] == 0
+        Expect ll[3]['valid'] == 1
+        Expect ll[3]['type'] == 'E'
+        Expect ll[3]['text'] == "E0602 Undefined variable 'unknown' [pylint]"
     end
 
 end

--- a/t/plugin.vim
+++ b/t/plugin.vim
@@ -1,7 +1,7 @@
 describe 'pymode-plugin'
 
     before
-        source  plugin/pymode.vim 
+        source  plugin/pymode.vim
         set filetype=python
     end
 
@@ -28,6 +28,8 @@ describe 'pymode-plugin'
     end
 
     it 'pymode save'
+        bd!
+        bd!
         Expect expand('%') == ''
         Expect pymode#save() == 0
     end
@@ -38,7 +40,7 @@ end
 describe 'pymode-python-disable'
     before
         let g:pymode_python = 'disable'
-        source  plugin/pymode.vim 
+        source  plugin/pymode.vim
         set filetype=python
     end
 

--- a/t/rope.vim
+++ b/t/rope.vim
@@ -3,7 +3,7 @@ let g:pymode_rope_autoimport = 0
 let g:pymode_debug = 1
 let g:pymode_rope_lookup_project = 0
 
-source  plugin/pymode.vim 
+source  plugin/pymode.vim
 
 describe 'pymode-plugin'
 
@@ -17,17 +17,12 @@ describe 'pymode-plugin'
     end
 
     it 'pymode rope auto open project in current working directory'
-
-        if $TRAVIS != ""
-            SKIP 'Travis fails on this test'
-        endif
-
-        let project_path = getcwd() . '/.ropeproject'
+        let project_path = getcwd() . system("mktemp -u /.ropeproject.XXXXXX | tr -d '\n'")
         Expect isdirectory(project_path)  == 0
+        let g:pymode_rope_project_root = project_path
         normal oimporX
         Expect getline('.') == 'import'
-        Expect g:pymode_rope_current == getcwd() . '/'
-        Expect g:pymode_rope_current . '.ropeproject' == project_path
+        Expect g:pymode_rope_current == project_path . '/'
         Expect isdirectory(project_path)  == 1
     end
 

--- a/t/test.py
+++ b/t/test.py
@@ -3,6 +3,7 @@
 
 
 def main():
-    unused = 1
+    rc=1
+    return rc
 
 unknown()


### PR DESCRIPTION
If pymode_folding is enabled, enabling diff mode or running vimdiff causes a freeze that is due to pymode#folding#text() being repeatedly called. You can stop all the folding process by pressing ctrl-c 4 times but it goes again into the infinite loop if you make any movement.
