### PR TITLE
Folding for `async def` subroutines

### DIFF
--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -39,7 +39,7 @@ call pymode#default("g:pymode_folding", 1)
 " Maximum file length to check for nested class/def statements
 call pymode#default("g:pymode_folding_nest_limit", 1000)
 " Change for folding customization (by example enable fold for 'if', 'for')
-call pymode#default("g:pymode_folding_regex", '^\s*\%(class\|def\) \w\+')
+call pymode#default("g:pymode_folding_regex", '^\s*\%(class\|def\|async\s\+def\) \w\+')
 
 " Enable/disable python motion operators
 call pymode#default("g:pymode_motion", 1)


### PR DESCRIPTION
Fix folding of "async def" functions.
I don't know how to make it toggleable, but I suppose it should not cause problems on older python versions anyway
