### PR TITLE
Fix testcases

### DIFF
--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -435,7 +435,7 @@ use the current directory.
 
 The location of the `.ropeproject` folder may also be overridden if you wish to
 keep it outside of your project root. The rope library treats this folder as a
-project resource, so the path will always be relative to your proejct root (a
+project resource, so the path will always be relative to your project root (a
 leading '/' will be ignored). You may use `'..'` path segments to place the
 folder outside of your project root.
                                                  *'g:pymode_rope_ropefolder'*

--- a/pymode/lint.py
+++ b/pymode/lint.py
@@ -4,6 +4,16 @@ from .environment import env
 from .utils import silence_stderr
 
 import os.path
+import vim
+
+
+from pylama.lint.extensions import LINTERS
+
+try:
+    from pylama.lint.pylama_pylint import Linter
+    LINTERS['pylint'] = Linter()
+except Exception: # noqa
+    pass
 
 
 from pylama.lint.extensions import LINTERS
@@ -37,6 +47,9 @@ def code_check():
             ignore=env.var('g:pymode_lint_ignore'),
             select=env.var('g:pymode_lint_select'),
         )
+        linters_keys = [l[0] for l in options.linters]
+        if vim.current.buffer.options['modified'] and 'pylint' in linters_keys:
+            del options.linters[linters_keys.index('pylint')]
 
         for linter in linters:
             opts = env.var('g:pymode_lint_options_%s' % linter, silence=True)

--- a/t/lint.vim
+++ b/t/lint.vim
@@ -1,4 +1,4 @@
-source  plugin/pymode.vim 
+source  plugin/pymode.vim
 
 describe 'pymode check code'
 
@@ -15,7 +15,7 @@ describe 'pymode check code'
     end
 
     it 'lint new'
-        put =['# coding: utf-8', 'call_unknown_function()']
+        put =['# coding: utf-8', 'x = 1']
         PymodeLint
         Expect getloclist(0) ==  []
     end
@@ -23,8 +23,21 @@ describe 'pymode check code'
     it 'lint code'
         e t/test.py
         PymodeLint
-        Expect getloclist(0) ==  [{'lnum': 6, 'bufnr': 1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'pattern': '', 'text': 'W0612 local variable "unused" is assigned to but never used [pyflakes]'}, {'lnum': 8, 'bufnr': 1, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'pattern': '', 'text': 'E0602 undefined name "unknown" [pyflakes]'}]
+        let ll = getloclist(0)
+
+        Expect len(ll) == 2
+
+        Expect ll[0]['lnum'] == 6
+        Expect ll[0]['col'] == 7
+        Expect ll[0]['type'] == 'C'
+        Expect ll[0]['valid'] == 1
+        Expect ll[0]['text'] == 'E225 missing whitespace around operator [pep8]'
+
+        Expect ll[1]['lnum'] == 9
+        Expect ll[1]['col'] == 1
+        Expect ll[1]['type'] == 'E'
+        Expect ll[1]['valid'] == 1
+        Expect ll[1]['text'] == "E0602 undefined name 'unknown' [pyflakes]"
     end
 
 end
-

--- a/t/lint.vim
+++ b/t/lint.vim
@@ -25,19 +25,31 @@ describe 'pymode check code'
         PymodeLint
         let ll = getloclist(0)
 
-        Expect len(ll) == 2
+        Expect len(ll) == 4
 
-        Expect ll[0]['lnum'] == 6
-        Expect ll[0]['col'] == 7
-        Expect ll[0]['type'] == 'C'
+        Expect ll[0]['lnum'] == 1
+        Expect ll[0]['col'] == 0
         Expect ll[0]['valid'] == 1
-        Expect ll[0]['text'] == 'E225 missing whitespace around operator [pep8]'
+        Expect ll[0]['type'] == 'C'
+        Expect ll[0]['text'] == "C0111 Missing module docstring [pylint]"
 
-        Expect ll[1]['lnum'] == 9
-        Expect ll[1]['col'] == 1
-        Expect ll[1]['type'] == 'E'
+        Expect ll[1]['lnum'] == 5
+        Expect ll[1]['col'] == 0
         Expect ll[1]['valid'] == 1
-        Expect ll[1]['text'] == "E0602 undefined name 'unknown' [pyflakes]"
+        Expect ll[1]['type'] == 'C'
+        Expect ll[1]['text'] == "C0111 Missing function docstring [pylint]"
+
+        Expect ll[2]['lnum'] == 6
+        Expect ll[2]['col'] == 7
+        Expect ll[2]['valid'] == 1
+        Expect ll[2]['type'] == 'C'
+        Expect ll[2]['text'] == "E225 missing whitespace around operator [pep8]"
+
+        Expect ll[3]['lnum'] == 9
+        Expect ll[3]['col'] == 0
+        Expect ll[3]['valid'] == 1
+        Expect ll[3]['type'] == 'E'
+        Expect ll[3]['text'] == "E0602 Undefined variable 'unknown' [pylint]"
     end
 
 end

--- a/t/lint.vim
+++ b/t/lint.vim
@@ -1,4 +1,4 @@
-source  plugin/pymode.vim
+source  plugin/pymode.vim 
 
 describe 'pymode check code'
 

--- a/t/plugin.vim
+++ b/t/plugin.vim
@@ -1,7 +1,7 @@
 describe 'pymode-plugin'
 
     before
-        source  plugin/pymode.vim 
+        source  plugin/pymode.vim
         set filetype=python
     end
 
@@ -28,6 +28,8 @@ describe 'pymode-plugin'
     end
 
     it 'pymode save'
+        bd!
+        bd!
         Expect expand('%') == ''
         Expect pymode#save() == 0
     end
@@ -38,7 +40,7 @@ end
 describe 'pymode-python-disable'
     before
         let g:pymode_python = 'disable'
-        source  plugin/pymode.vim 
+        source  plugin/pymode.vim
         set filetype=python
     end
 

--- a/t/rope.vim
+++ b/t/rope.vim
@@ -3,7 +3,7 @@ let g:pymode_rope_autoimport = 0
 let g:pymode_debug = 1
 let g:pymode_rope_lookup_project = 0
 
-source  plugin/pymode.vim 
+source  plugin/pymode.vim
 
 describe 'pymode-plugin'
 
@@ -17,17 +17,12 @@ describe 'pymode-plugin'
     end
 
     it 'pymode rope auto open project in current working directory'
-
-        if $TRAVIS != ""
-            SKIP 'Travis fails on this test'
-        endif
-
-        let project_path = getcwd() . '/.ropeproject'
+        let project_path = getcwd() . system("mktemp -u /.ropeproject.XXXXXX | tr -d '\n'")
         Expect isdirectory(project_path)  == 0
+        let g:pymode_rope_project_root = project_path
         normal oimporX
         Expect getline('.') == 'import'
-        Expect g:pymode_rope_current == getcwd() . '/'
-        Expect g:pymode_rope_current . '.ropeproject' == project_path
+        Expect g:pymode_rope_current == project_path . '/'
         Expect isdirectory(project_path)  == 1
     end
 

--- a/t/test.py
+++ b/t/test.py
@@ -3,6 +3,7 @@
 
 
 def main():
-    unused = 1
+    rc=1
+    return rc
 
 unknown()


### PR DESCRIPTION
Completing the fix suggested in #581. The repo is rebased to fix the rope test. lint test was failing because of changes in lint. There was also an issue that previously was not caught. It looks like pylint cannot process a buffer. So in cases that the buffer is not saved, this would give an error like this:

`F0010 error while code parsing: Unable to load file '__init__.py' ([Errno 2] No such file or directory: '__init__.py') [pylint]`

I added a temporary fix to not run pylint if the buffer is not saved.
