### PR TITLE
Rope move function to another module

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -695,6 +695,19 @@ class MoveRefactoring(Refactoring):
             offset = None
         return move.create_move(ctx.project, ctx.resource, offset)
 
+    @staticmethod
+    def get_changes(refactor, input_str, in_hierarchy=False):
+        """ Get changes.
+
+        :return Changes:
+
+        """
+        if isinstance(refactor, move.MoveGlobal):
+            changes_dest = refactor.project.get_resource(input_str)
+        else:
+            changes_dest = input_str
+        return refactor.get_changes(changes_dest)
+
 
 class ChangeSignatureRefactoring(Refactoring):
 


### PR DESCRIPTION
Is it possible to do?

I see Rope is capable of moving global function between modules [1][2] but when I enter `<C-c>rv` on function name and give It destination module name or path, I get:

> 'str' object has no attribute 'exists'

1: https://github.com/python-rope/rope/blob/master/docs/rope.rst
2: https://github.com/python-rope/rope/blob/master/rope/refactor/move.py#L199
