### PR TITLE
Absolute paths for virtualenv activation

### DIFF
--- a/autoload/pymode/virtualenv.vim
+++ b/autoload/pymode/virtualenv.vim
@@ -11,7 +11,7 @@ fun! pymode#virtualenv#init() "{{{
 
 endfunction "}}}
 
-fun! pymode#virtualenv#activate(relpath) "{{{
-    let g:pymode_virtualenv_path = getcwd() . '/' . a:relpath
+fun! pymode#virtualenv#activate(path) "{{{
+    let g:pymode_virtualenv_path = a:path
     call pymode#virtualenv#init()
 endfunction "}}}

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -212,8 +212,8 @@ Bind keys to show documentation for current word (selection)
                                                              *pymode-virtualenv*
 
 Commands:
-*:PymodeVirtualenv* <path> -- Activate virtualenv (path is related to
-current working directory)
+*:PymodeVirtualenv* <path> -- Activate virtualenv (path can be absolute or
+relative to current working directory)
 
 Enable automatic virtualenv detection                     *'g:pymode_virtualenv'*
 >

--- a/pymode/virtualenv.py
+++ b/pymode/virtualenv.py
@@ -15,6 +15,11 @@ def enable_virtualenv():
 
     """
     path = env.var('g:pymode_virtualenv_path')
+    # Normalize path to be an absolute path
+    # If an absolute path is provided, that path will be returned, otherwise
+    # the returned path will be an absolute path but computed relative
+    # to the current working directory
+    path = os.path.abspath(path)
     enabled = env.var('g:pymode_virtualenv_enabled')
     if path == enabled:
         env.message('Virtualenv %s already enabled.' % path)

--- a/t/virtualenv.vim
+++ b/t/virtualenv.vim
@@ -1,0 +1,28 @@
+describe 'pymode-virtualenv'
+
+    before
+        source  plugin/pymode.vim 
+        set filetype=python
+    end
+
+    after
+        bd!
+    end
+
+    " TODO: How can we mock the virtualenv activation to check that the
+    " proper path is set to pymode_virtualenv_enabled? Right now, the 
+    " python function enable_virtualenv gets called but fails when trying
+    " to actually activate so the env.let never gets called
+
+    it 'accepts relative paths'
+        call pymode#virtualenv#activate("sample/relative/path")
+        " Our path variable is the path argument
+        Expect g:pymode_virtualenv_path == "sample/relative/path"
+    end
+
+    it 'accepts absolute paths'
+        call pymode#virtualenv#activate("/sample/absolute/path")
+        " Our path variable is the path argument
+        Expect g:pymode_virtualenv_path == "/sample/absolute/path"
+    end
+end


### PR DESCRIPTION
This will allow you to specify an absolute path when activating a virtual environment. This can be useful for people using `virtualenvwrapper` where all of your environments are typically kept in some folder under your home directory.

Before:
```
:PymodeVirtualenv "/Users/matt/venv/myenv"
[Pymode]: error: [Errno 2] No such file or directory: '/Users/matt/code/Users/matt/venv/myvenv'
```

After:
```
:PymodeVirtualenv "/Users/matt/venv/myenv"
[Pymode] Activate virtualenv: /Users/matt/venv/myenv
```

It also adds a rather dumb unit test for the virtualenv command. My vim-script-noobness has left me unable to make it smarter. I added a TODO for someone that knows what they are doing to hopefully help.