### PR TITLE
Do support underscore in numbers, pep515 (py3.6)

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -254,10 +254,10 @@ endif
     syn match   pythonHexNumber "\<0[xX][0-9a-fA-F_]*[0-9a-fA-F][0-9a-fA-F_]*[lL]\=\>" display
     syn match   pythonOctNumber "\<0[oO][0-7_]*[0-7][0-7_]*[lL]\=\>" display
     syn match   pythonBinNumber "\<0[bB][01_]*[01][01_]*[lL]\=\>" display
-    syn match   pythonNumber    "\<[0-9_]*[0-9][0-9_]*[lLjJ]\=\>" display
+    syn match   pythonNumber    "\<[0-9][0-9_]*[lLjJ]\=\>" display
     syn match   pythonFloat "\.[0-9_]*[0-9][0-9_]*\([eE][+-]\=[0-9_]*[0-9][0-9_]*\)\=[jJ]\=\>" display
-    syn match   pythonFloat "\<[0-9_]*[0-9][0-9_]*[eE][+-]\=[0-9_]\+[jJ]\=\>" display
-    syn match   pythonFloat "\<[0-9_]*[0-9][0-9_]*\.[0-9_]*\([eE][+-]\=[0-9_]*[0-9][0-9_]*\)\=[jJ]\=" display
+    syn match   pythonFloat "\<[0-9][0-9_]*[eE][+-]\=[0-9_]\+[jJ]\=\>" display
+    syn match   pythonFloat "\<[0-9][0-9_]*\.[0-9_]*\([eE][+-]\=[0-9_]*[0-9][0-9_]*\)\=[jJ]\=" display
     syn match   pythonOctError  "\<0[oO]\=[0-7_]*[8-9][0-9_]*[lL]\=\>" display
     syn match   pythonBinError  "\<0[bB][01_]*[2-9][0-9_]*[lL]\=\>" display
 

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -251,13 +251,13 @@ endif
 " ===========
 
     syn match   pythonHexError  "\<0[xX][0-9a-fA-F_]*[g-zG-Z][0-9a-fA-F_]*[lL]\=\>" display
-    syn match   pythonHexNumber "\<0[xX][0-9a-fA-F_]\+[lL]\=\>" display
-    syn match   pythonOctNumber "\<0[oO][0-7_]\+[lL]\=\>" display
-    syn match   pythonBinNumber "\<0[bB][01_]\+[lL]\=\>" display
-    syn match   pythonNumber    "\<[0-9_]\+[lLjJ]\=\>" display
-    syn match   pythonFloat "\.[0-9_]\+\([eE][+-]\=[0-9_]\+\)\=[jJ]\=\>" display
-    syn match   pythonFloat "\<[0-9_]\+[eE][+-]\=[0-9_]\+[jJ]\=\>" display
-    syn match   pythonFloat "\<[0-9_]\+\.[0-9_]*\([eE][+-]\=[0-9_]\+\)\=[jJ]\=" display
+    syn match   pythonHexNumber "\<0[xX][0-9a-fA-F_]*[0-9a-fA-F][0-9a-fA-F_]*[lL]\=\>" display
+    syn match   pythonOctNumber "\<0[oO][0-7_]*[0-7][0-7_]*[lL]\=\>" display
+    syn match   pythonBinNumber "\<0[bB][01_]*[01][01_]*[lL]\=\>" display
+    syn match   pythonNumber    "\<[0-9_]*[0-9][0-9_]*[lLjJ]\=\>" display
+    syn match   pythonFloat "\.[0-9_]*[0-9][0-9_]*\([eE][+-]\=[0-9_]*[0-9][0-9_]*\)\=[jJ]\=\>" display
+    syn match   pythonFloat "\<[0-9_]*[0-9][0-9_]*[eE][+-]\=[0-9_]\+[jJ]\=\>" display
+    syn match   pythonFloat "\<[0-9_]*[0-9][0-9_]*\.[0-9_]*\([eE][+-]\=[0-9_]*[0-9][0-9_]*\)\=[jJ]\=" display
     syn match   pythonOctError  "\<0[oO]\=[0-7_]*[8-9][0-9_]*[lL]\=\>" display
     syn match   pythonBinError  "\<0[bB][01_]*[2-9][0-9_]*[lL]\=\>" display
 

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -250,16 +250,16 @@ endif
 " Numbers {{{
 " ===========
 
-    syn match   pythonHexError  "\<0[xX]\x*[g-zG-Z]\x*[lL]\=\>" display
-    syn match   pythonHexNumber "\<0[xX]\x\+[lL]\=\>" display
-    syn match   pythonOctNumber "\<0[oO]\o\+[lL]\=\>" display
-    syn match   pythonBinNumber "\<0[bB][01]\+[lL]\=\>" display
-    syn match   pythonNumber    "\<\d\+[lLjJ]\=\>" display
-    syn match   pythonFloat "\.\d\+\([eE][+-]\=\d\+\)\=[jJ]\=\>" display
-    syn match   pythonFloat "\<\d\+[eE][+-]\=\d\+[jJ]\=\>" display
-    syn match   pythonFloat "\<\d\+\.\d*\([eE][+-]\=\d\+\)\=[jJ]\=" display
-    syn match   pythonOctError  "\<0[oO]\=\o*[8-9]\d*[lL]\=\>" display
-    syn match   pythonBinError  "\<0[bB][01]*[2-9]\d*[lL]\=\>" display
+    syn match   pythonHexError  "\<0[xX][0-9a-fA-F_]*[g-zG-Z][0-9a-fA-F_]*[lL]\=\>" display
+    syn match   pythonHexNumber "\<0[xX][0-9a-fA-F_]\+[lL]\=\>" display
+    syn match   pythonOctNumber "\<0[oO][0-7_]\+[lL]\=\>" display
+    syn match   pythonBinNumber "\<0[bB][01_]\+[lL]\=\>" display
+    syn match   pythonNumber    "\<[0-9_]\+[lLjJ]\=\>" display
+    syn match   pythonFloat "\.[0-9_]\+\([eE][+-]\=[0-9_]\+\)\=[jJ]\=\>" display
+    syn match   pythonFloat "\<[0-9_]\+[eE][+-]\=[0-9_]\+[jJ]\=\>" display
+    syn match   pythonFloat "\<[0-9_]\+\.[0-9_]*\([eE][+-]\=[0-9_]\+\)\=[jJ]\=" display
+    syn match   pythonOctError  "\<0[oO]\=[0-7_]*[8-9][0-9_]*[lL]\=\>" display
+    syn match   pythonBinError  "\<0[bB][01_]*[2-9][0-9_]*[lL]\=\>" display
 
 " }}}
 


### PR DESCRIPTION
Python 3.6 introduced [PEP 515](https://www.python.org/dev/peps/pep-0515/) which allows underscore character (`_`) in numeric literals. This commit is intended to properly highlight such literals.