### PR TITLE
Updated docstring regex to allow folding of raw python strings

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -9,12 +9,12 @@ let s:blank_regex = '^\s*$'
 " Spyder, a very popular IDE for python has a template which includes
 " '@author:' ; thus the regex below.
 let s:decorator_regex = '^\s*@\(author:\)\@!' 
-let s:doc_begin_regex = '^\s*[uU]\=\%("""\|''''''\)'
+let s:doc_begin_regex = '^\s*[uUrR]\=\%("""\|''''''\)'
 let s:doc_end_regex = '\%("""\|''''''\)\s*$'
 " This one is needed for the while loop to count for opening and closing
 " docstrings.
 let s:doc_general_regex = '\%("""\|''''''\)'
-let s:doc_line_regex = '^\s*[uU]\=\("""\|''''''\).\+\1\s*$'
+let s:doc_line_regex = '^\s*[uUrR]\=\("""\|''''''\).\+\1\s*$'
 let s:symbol = matchstr(&fillchars, 'fold:\zs.')  " handles multibyte characters
 if s:symbol == ''
     let s:symbol = ' '
@@ -42,7 +42,7 @@ fun! pymode#folding#text() " {{{
     let line = substitute(line, '\t', onetab, 'g')
 
     let line = strpart(line, 0, windowwidth - 2 -len(foldedlinecount))
-    let line = substitute(line, '[uU]\=\%("""\|''''''\)', '', '')
+    let line = substitute(line, '[uUrR]\=\%("""\|''''''\)', '', '')
     let fillcharcount = windowwidth - len(line) - len(foldedlinecount) + 1
     return line . ' ' . repeat(s:symbol, fillcharcount) . ' ' . foldedlinecount
 endfunction "}}}


### PR DESCRIPTION
pymode folding recognizes docstring styles (''', """) and the unicode u, U prefix (u''', u""") but does not recognize a raw prefix. This pull request adds this functionality. 