### PR TITLE
Enable all ImportOrganzier methods to be called

### DIFF
--- a/autoload/pymode/rope.vim
+++ b/autoload/pymode/rope.vim
@@ -55,6 +55,37 @@ fun! pymode#rope#organize_imports()
     PymodePython rope.organize_imports()
 endfunction
 
+fun! pymode#rope#expand_star_imports()
+    if !pymode#save()
+        return 0
+    endif
+    call pymode#wide_message('Expand star imports ... ')
+    PymodePython rope.expand_star_imports()
+endfunction
+
+fun! pymode#rope#froms_to_imports()
+    if !pymode#save()
+        return 0
+    endif
+    call pymode#wide_message('From to imports ... ')
+    PymodePython rope.froms_to_imports()
+endfunction
+
+fun! pymode#rope#relatives_to_absolutes()
+    if !pymode#save()
+        return 0
+    endif
+    call pymode#wide_message('Relatives to absolutes ... ')
+    PymodePython rope.relatives_to_absolutes()
+endfunction
+
+fun! pymode#rope#handle_long_imports()
+    if !pymode#save()
+        return 0
+    endif
+    call pymode#wide_message('Handle long imports ... ')
+    PymodePython rope.handle_long_imports()
+endfunction
 
 fun! pymode#rope#find_it()
     let loclist = g:PymodeLocList.current()

--- a/ftplugin/python/pymode.vim
+++ b/ftplugin/python/pymode.vim
@@ -204,6 +204,10 @@ if g:pymode_rope
     command! -buffer PymodeRopeRenameModule call pymode#rope#rename_module()
     command! -buffer PymodeRopeModuleToPackage call pymode#rope#module_to_package()
     command! -buffer PymodeRopeRegenerate call pymode#rope#regenerate()
+    command! -buffer PymodeRopeExpandStarImports call pymode#rope#expand_star_imports()
+    command! -buffer PymodeRopeFromsToImports call pymode#rope#froms_to_imports()
+    command! -buffer PymodeRopeRelateToAbsolutes call pymode#rope#relatives_to_absolutes()
+    command! -buffer PymodeRopeHandleLongImports call pymode#rope#handle_long_imports()
 
     if g:pymode_rope_autoimport
         command! -buffer PymodeRopeAutoImport call pymode#rope#autoimport(expand('<cword>'))


### PR DESCRIPTION
Currently only organize_imports from ImportOrganzier is exported; But
there are four more methods available:
 * expand_star_imports
 * froms_to_imports
 * relatives_to_absolutes
 * handle_long_imports
We'll expose these as vim commands