### PR TITLE
Viewing documentation autoswitches to preview window

### DIFF
--- a/autoload/pymode/doc.vim
+++ b/autoload/pymode/doc.vim
@@ -32,6 +32,6 @@ fun! pymode#doc#show(word) "{{{
     if g:pymode_doc_vertical
         wincmd L
     endif
-    wincmd p
+    wincmd P
 
 endfunction "}}}


### PR DESCRIPTION
In the file doc.vim,  `wincmd p` should be `windmd P`

Signed-off-by: Matthew Roseman <mroseman95@gmail.com>