### PR TITLE
fix the help command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ See (very old) screencast here: http://www.youtube.com/watch?v=67OZNp9Z0CQ
 (sorry for quality, this is my first screencast) Another old presentation here:
 http://www.youtube.com/watch?v=YhqsjUUHj6g
 
-**To read python-mode documentation in Vim, see** ``:help pymode``
+**To read python-mode documentation in Vim, see** ``:help python-vim``
 
 
 .. contents::


### PR DESCRIPTION
it looks like that I should use `:help python-vim` to start the documentation.