### PR TITLE
Make Folding of Docstrings Optional

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -99,17 +99,19 @@ fun! pymode#folding#expr(lnum) "{{{
         return "="
     endif
 
-    if line =~ s:doc_begin_regex
-            " echom 'just entering'
-        if s:Is_opening_folding(a:lnum)
-            " echom 'entering at line ' . a:lnum
-            return ">".(indent / &shiftwidth + 1)
+    if g:pymode_fold_docstrings
+        if line =~ s:doc_begin_regex
+                " echom 'just entering'
+            if s:Is_opening_folding(a:lnum)
+                " echom 'entering at line ' . a:lnum
+                return ">".(indent / &shiftwidth + 1)
+            endif
         endif
-    endif
-    if line =~ s:doc_end_regex
-        if !s:Is_opening_folding(a:lnum)
-            " echom 'leaving at line ' . a:lnum
-            return "<".(indent / &shiftwidth + 1)
+        if line =~ s:doc_end_regex
+            if !s:Is_opening_folding(a:lnum)
+                " echom 'leaving at line ' . a:lnum
+                return "<".(indent / &shiftwidth + 1)
+            endif
         endif
     endif "}}}
 

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -38,6 +38,8 @@ call pymode#default("g:pymode_indent", 1)
 call pymode#default("g:pymode_folding", 1)
 " Maximum file length to check for nested class/def statements
 call pymode#default("g:pymode_folding_nest_limit", 1000)
+" Enable/disable pymode folding of docstrings.
+call pymode#default("g:pymode_fold_docstrings", 1)
 " Change for folding customization (by example enable fold for 'if', 'for')
 call pymode#default("g:pymode_folding_regex", '^\s*\%(class\|def\|async\s\+def\) .\+\(:\s\+\w\)\@!')
 


### PR DESCRIPTION
I prefer _not_ to fold my docstrings, so I added this additional option.