### PR TITLE
Add pep257 linter option on source comment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Contributors:
 * Daniel Hahler (http://github.com/blueyed)
 * David Vogt (http://github.com/winged);
 * Denis Kasak (http://github.com/dkasak);
+* Diego Rabatone Oliveira (https://github.com/diraol)
 * Dimitrios Semitsoglou-Tsiapos (https://github.com/dset0x);
 * Dirk Wallenstein (http://github.com/dirkwallenstein);
 * Florent Xicluna (http://github.com/florentx);

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -106,7 +106,7 @@ call pymode#default("g:pymode_lint_on_fly", 0)
 " Show message about error in command line
 call pymode#default("g:pymode_lint_message", 1)
 
-" Choices are: pylint, pyflakes, pep8, mccabe
+" Choices are: pylint, pyflakes, pep8, mccabe and pep257
 call pymode#default("g:pymode_lint_checkers", ['pyflakes', 'pep8', 'mccabe'])
 
 " Skip errors and warnings (e.g. E4,W)


### PR DESCRIPTION
On the documentation (`README.md` and `doc/pymode.txt`) `pep257` is described as a possible option as a linter, but on the source code comment it was not, I'm just setting it over there to make sure anyone reading the source code knows their options. =)