### PR TITLE
Modify loclist to separate errors from warnings

### DIFF
--- a/autoload/pymode/lint.vim
+++ b/autoload/pymode/lint.vim
@@ -68,7 +68,7 @@ fun! pymode#lint#check() "{{{
     call loclist.show()
 
     call pymode#lint#show_errormessage()
-    call pymode#wide_message('Found errors and warnings: ' . len(loclist._loclist))
+    call pymode#wide_message('Found ' . loclist.num_errors() . ' error(s) and ' . loclist.num_warnings() . ' warning(s)')
 
 endfunction " }}}
 

--- a/autoload/pymode/tools/loclist.vim
+++ b/autoload/pymode/tools/loclist.vim
@@ -24,19 +24,37 @@ endfunction "}}}
 
 
 fun! g:PymodeLocList.is_empty() "{{{
-    return empty(self._loclist)
+    return empty(self._errlist) && empty(self._warnlist)
+endfunction "}}}
+
+fun! g:PymodeLocList.loclist() "{{{
+    let loclist = copy(self._errlist)
+    call extend(loclist, self._warnlist)
+    return loclist
+endfunction "}}}
+
+fun! g:PymodeLocList.num_errors() "{{{
+    return len(self._errlist)
+endfunction "}}}
+
+fun! g:PymodeLocList.num_warnings() "{{{
+    return len(self._warnlist)
 endfunction "}}}
 
 
 fun! g:PymodeLocList.clear() "{{{
-    let self._loclist = []
+    let self._errlist = []
+    let self._warnlist = []
     let self._messages = {}
     let self._name = expand('%:t')
 endfunction "}}}
 
 
 fun! g:PymodeLocList.extend(raw_list) "{{{
-    call extend(self._loclist, a:raw_list)
+    let err_list = filter(copy(a:raw_list), 'v:val["type"] == "E"')
+    let warn_list = filter(copy(a:raw_list), 'v:val["type"] != "E"')
+    call extend(self._errlist, err_list)
+    call extend(self._warnlist, warn_list)
     for issue in a:raw_list
         let self._messages[issue.lnum] = issue.text
     endfor
@@ -46,7 +64,7 @@ endfunction "}}}
 
 fun! g:PymodeLocList.filter(filters) "{{{
     let loclist = []
-    for error in self._loclist
+    for error in self.loclist()
         let passes_filters = 1
         for key in keys(a:filters)
             if get(error, key, '') !=? a:filters[key]
@@ -65,8 +83,9 @@ endfunction "}}}
 
 
 fun! g:PymodeLocList.show() "{{{
-    call setloclist(0, self._loclist)
-    if self.is_empty()
+    call setloclist(0, self.loclist())
+    "if self.is_empty()
+    if self.num_errors() == 0 
         lclose
     elseif g:pymode_lint_cwindow
         let num = winnr()
@@ -77,5 +96,6 @@ fun! g:PymodeLocList.show() "{{{
             call setwinvar(winnr(), 'quickfix_title', self._title . ' <' . self._name . '>')
             exe num . "wincmd w"
         endif
+        lfirst
     end
 endfunction "}}}

--- a/autoload/pymode/tools/signs.vim
+++ b/autoload/pymode/tools/signs.vim
@@ -46,7 +46,7 @@ endfunction "}}}
 
 fun! g:PymodeSigns.place(loclist) "{{{
     let seen = {}
-    for issue in a:loclist._loclist
+    for issue in a:loclist.loclist()
         if !has_key(seen, issue.lnum)
             let seen[issue.lnum] = 1
             call add(self._sign_ids, self._next_id)

--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -184,7 +184,7 @@ def find_it():
             text=env.lines[oc.lineno - 1] if oc.resource.real_path == env.curbuf.name else "", # noqa
             lnum=oc.lineno,
         ))
-    env.let('loclist._loclist', lst)
+    env.run('g:PymodeLocList.current().extend', lst)
 
 
 def update_python_path(paths):


### PR DESCRIPTION
- Separate errors from warnings (errors are shown above warnings)
- [g:pymode_lint_cwindow] open loclist only if there is at least one error (not warnings)
- [g:pymode_lint_cwindow] jump to first error

Changes to be committed:
	modified:   autoload/pymode/lint.vim
	modified:   autoload/pymode/tools/loclist.vim
	modified:   autoload/pymode/tools/signs.vim
	modified:   pymode/rope.py