### PR TITLE
Fix #728, pass rope project to ImportTools init

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -893,7 +893,7 @@ def _insert_import(name, module, ctx):
         return True
 
     pyobject = ctx.project.pycore.resource_to_pyobject(ctx.resource)
-    import_tools = importutils.ImportTools(ctx.project.pycore)
+    import_tools = importutils.ImportTools(ctx.project)
     module_imports = import_tools.module_imports(pyobject)
     new_import = importutils.FromImport(module, 0, [[name, None]])
     module_imports.add_import(new_import)


### PR DESCRIPTION
Fix for #728 . As noted by @pieterdd and @soulomoon calling autoimport results in AttributeError. Rope ImportTools expect to get Project object as input argument to init function not PyCore object.