### PR TITLE
Fix pydocstyle submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
     ignore = dirty
 [submodule "submodules/pydocstyle"]
 	path = submodules/pydocstyle
-	url = https://github.com/PyCQA/pydocstyle/
+	url = https://github.com/PyCQA/pydocstyle
     ignore = dirty
 [submodule "submodules/mccabe"]
 	path = submodules/mccabe


### PR DESCRIPTION
The submodule URL for `PyCQA/pydocstyle` was incorrect so doing `git clone --recursive ...` failed with the following error:

```
Cloning into '/Users/makram/.vim/bundle/python-mode/submodules/pydocstyle'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/PyCQA/pydocstyle/' into submodule path '/Users/makram/.vim/bundle/python-mode/submodules/pydocstyle' failed
Failed to clone 'submodules/pydocstyle'. Retry scheduled

...

Cloning into '/Users/makram/.vim/bundle/python-mode/submodules/pydocstyle'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/PyCQA/pydocstyle/' into submodule path '/Users/makram/.vim/bundle/python-mode/submodules/pydocstyle' failed
Failed to clone 'submodules/pydocstyle' a second time, aborting
```

I'm on OS X and I'm wondering if there's a discrepancy between OS X `git` and Linux `git` 🤷‍♂️ 