### PR TITLE
if g:pymode_breakpoint_cmd is empty, skip pymode#breakpoint#operate

### DIFF
--- a/autoload/pymode/breakpoint.vim
+++ b/autoload/pymode/breakpoint.vim
@@ -11,7 +11,7 @@ fun! pymode#breakpoint#init() "{{{
 
 from imp import find_module
 
-for module in ('wdb', 'pudb', 'ipdb'):
+for module in ('wdb', 'pudb', 'ipdb', 'pdb'):
     try:
         find_module(module)
         vim.command('let g:pymode_breakpoint_cmd = "import %s; %s.set_trace()  # XXX BREAKPOINT"' % (module, module))
@@ -25,6 +25,10 @@ EOF
 endfunction "}}}
 
 fun! pymode#breakpoint#operate(lnum) "{{{
+    if strlen(g:pymode_breakpoint_cmd) == 0
+        echoerr("g:pymode_breakpoint_cmd is empty")
+        return
+    endif
     let line = getline(a:lnum)
     if strridx(line, g:pymode_breakpoint_cmd) != -1
         normal dd


### PR DESCRIPTION
This PR aims to fix this:

When `g:pymode_breakpoint_cmd` is empty string, calling `pymode#breakpoint#operate` will just delete the given line, which can be confusing.

This is how:

* Added a error message to let user know what's gone wrong, and skip the rest since there's nothing to do really.
* When calculating `g:pymode_breakpoint_cmd`, try to find `pdb` package as well.