### PR TITLE
Clarify Pathogen installation procedure for recursive submodules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,8 @@ help packages` in vim for details.
 
     cd ~/.vim
     mkdir -p bundle && cd bundle
-    git clone https://github.com/python-mode/python-mode.git
+    git clone --recursive https://github.com/python-mode/python-mode.git
+
 
 Enable [pathogen](https://github.com/tpope/vim-pathogen) in your `~/.vimrc`:
 

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,6 @@ help packages` in vim for details.
     cd python-mode
     git submodule update --init --recursive
 
-
 ## Using pathogen
 
     cd ~/.vim


### PR DESCRIPTION
Added the --recursive flag to the clone example for Pathogen install.