### PR TITLE
Improve user_input's input/raw_input compatibility.

### DIFF
--- a/pymode/environment.py
+++ b/pymode/environment.py
@@ -91,23 +91,30 @@ class VimPymodeEnviroment(object):
 
         return vim.command('call pymode#wide_message("%s")' % str(msg))
 
-    def user_input(self, msg, default=''):
+    def user_input(self, msg='', default=''):
         """Return user input or default.
 
         :return str:
 
         """
-        msg = '%s %s ' % (self.prefix, msg)
+        prompt = []
+        prompt.append(str(self.prefix.strip()))
+        prompt.append(str(msg).strip())
 
         if default != '':
-            msg += '[%s] ' % default
+            prompt.append('[%s]' % default)
+
+        prompt.append('> ')
+        prompt = ' '.join([s for s in prompt if s])
+
+        vim.command('echohl Debug')
 
         try:
-            vim.command('echohl Debug')
-            input_str = vim.eval('input("%s> ")' % msg)
-            vim.command('echohl none')
+            input_str = vim.eval('input(%r)' % (prompt,))
         except KeyboardInterrupt:
             input_str = ''
+
+        vim.command('echohl none')
 
         return input_str or default
 


### PR DESCRIPTION
This PR add the changes from #723 with the necessary rebase.

Quoting the PR comment:

    I didn't like having to add a prompt message when using python's
    input and running it with PymodeRun

        * Allow default prompt ('' empty string)
        * Fix quoting (input('"') would crash because it wasn't escaped)
        * Strip whitespace to avoid duplicate spaces

    Caveats:
    strips all leading and trailing whitespace from prefix and msg still
    doesn't write the prompt to stdout like input/raw_input does (to fix
    that one would need a separate function for replacing
    input/raw_input)

Close 723