### PR TITLE
Add proper vim-plug installation instructions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Maintainers:
 Contributors:
 
 * Alvin Francis (http://github.com/alvinfrancis);
+* Amir Eldor (https://github.com/amireldor)
 * Andriy Kohut (https://github.com/andriykohut)
 * Anler Hp (http://github.com/ikame);
 * Anton Parkhomenko (http://github.com/chuwy);

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,13 @@ Enable [pathogen](https://github.com/tpope/vim-pathogen) in your `~/.vimrc`:
     filetype plugin indent on
     syntax on
 
+## Using vim-plug
+
+Include the following in the [vim-plug](https://github.com/junegunn/vim-plug)
+section of your `~/.vimrc`:
+
+    Plug 'python-mode/python-mode', { 'branch': 'develop' }
+
 ## Manually
 
     % git clone https://github.com/python-mode/python-mode.git


### PR DESCRIPTION
Fixes #864 

Consider adding a note about using the `development` branch in case the user wants to install using another git-based vim plugin manager. 