### PR TITLE
Add submodules's path to sys.path for msys2 platform #852 with correc…

### DIFF
--- a/pymode/utils.py
+++ b/pymode/utils.py
@@ -38,7 +38,7 @@ def patch_paths():
     """
     dir_script = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, os.path.join(dir_script, 'libs'))
-    if sys.platform == 'win32':
+    if sys.platform == 'win32' or sys.platform == 'msys':
         dir_submodule = os.path.abspath(os.path.join(dir_script,
                                                      '..', 'submodules'))
         sub_modules = os.listdir(dir_submodule)


### PR DESCRIPTION
msys2 also can't create submodule links.