### PR TITLE
Add type key to found occurence.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Contributors:
 * Ashley Hewson (http://github.com/ashleyh);
 * Ben Davis (https://github.com/bendavis78);
 * Benjamin Ruston (http://github.com/bruston);
+* Boatx (https://github.com/boatx)
 * Boris Filippov (http://github.com/frenzykryger);
 * Brad Belyeu (https://github.com/bbelyeu);
 * Brad Mease (http://github.com/bmease)

--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -183,6 +183,7 @@ def find_it():
             filename=oc.resource.path,
             text=env.lines[oc.lineno - 1] if oc.resource.real_path == env.curbuf.name else "", # noqa
             lnum=oc.lineno,
+            type=''
         ))
     env.run('g:PymodeLocList.current().extend', lst)
 


### PR DESCRIPTION
Pressing `C-c f` results in IndexError because found occurrence dictionary don't have key 'type' (required by `g:PymodeLocList.extend`).

Related issue #921 

Explanation related to the fix retrieved from the related issue:

This error is related to ``PymodeLocList``. It is used to display places in code where rope has found occurences.

https://github.com/python-mode/python-mode/blob/bb746d0d0cba9adedbac856429e37a0dbfc599c6/autoload/pymode/rope.vim#L60

But it is also (or mostly used) by linters to display line of code with error of warnings (type 'E' or 'W'), when list of locations is extended new entries are filtered over type.

https://github.com/python-mode/python-mode/blob/bb746d0d0cba9adedbac856429e37a0dbfc599c6/autoload/pymode/tools/loclist.vim#L54

This type is later displayed next to line number. I wasn't sure what to put for rope so I've added empty string.