### PR TITLE
Remove pythonDot highlight match

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,3 +71,4 @@ Contributors:
 * Wayne Ye (https://github.com/WayneYe);
 * Wes Turner (https://github.com/westurner);
 * Xiangyu Xu (https://github.com/bkbncn);
+* Zach Himsel (https://github.com/zhimsel);

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -129,7 +129,6 @@ endif
 
     syn match   pythonDecorator "@" display nextgroup=pythonDottedName skipwhite
     syn match   pythonDottedName "[a-zA-Z_][a-zA-Z0-9_]*\(\.[a-zA-Z_][a-zA-Z0-9_]*\)*" display contained
-    syn match   pythonDot        "\." display containedin=pythonDottedName
 
 " }}}
 
@@ -349,7 +348,6 @@ endif
 
     hi def link  pythonDecorator    Define
     hi def link  pythonDottedName   Function
-    hi def link  pythonDot          Normal
 
     hi def link  pythonComment      Comment
     hi def link  pythonCoding       Special


### PR DESCRIPTION
When the `cursorcolumn` or `cursorline` vim option is set, _any_ `.` characters result in the highlighting being set to `Normal` (instead of blank). This means that the "highlighted" line (via `cursorline`) is broken over the period. Please see attached screenshot for an example:

![screen shot 2018-07-27 at 14 10 06](https://user-images.githubusercontent.com/5325723/43344419-e56f8b48-91a6-11e8-97e9-23cb811c37e7.png)

As far as I can tell, the `pythonDot` match doesn't really do anything except drop the highlighting back to `Normal` in a `pythonDottedName` match. This just seems useless, so I think we should just remove it and let the dots have the same highlight as the rest of the `pythonDottedName` matches.

The main reason for this PR was not for a specific issue (my highlighting issue was just a symptom). I submitted this PR because I noticed that the `pythonDot` highlight group seemed entirely pointless. All it does is drop the highlighting for any `.` characters to `Normal`. This doesn't seem to be expected or desired behavior (the `.` should match the surrounding highlight).