### PR TITLE
Check for `has('python3')` for default Python

### DIFF
--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -19,7 +19,7 @@ filetype plugin on
 " OPTIONS: {{{
 
 " Vim Python interpreter. Set to 'disable' for remove python features.
-if executable('python3')
+if executable('python3') && has('python3')
     call pymode#default('g:pymode_python', 'python3')
 else
     call pymode#default('g:pymode_python', 'python')


### PR DESCRIPTION
Check whether Python 3 support is provided by Vim before defaulting to it:
https://github.com/python-mode/python-mode/issues/938