### PR TITLE
Use importlib instead of imp when using python3

### DIFF
--- a/autoload/pymode/breakpoint.vim
+++ b/autoload/pymode/breakpoint.vim
@@ -9,16 +9,24 @@ fun! pymode#breakpoint#init() "{{{
 
         PymodePython << EOF
 
-from imp import find_module
+from six import PY3
+
+if PY3:
+    from importlib.util import find_spec
+    def module_exists(module_name):
+        return find_spec(module_name)
+else:
+    from imp import find_module
+    def module_exists(module_name):
+        try:
+            return find_module(module_name)
+        except ImportError:
+            return False
 
 for module in ('wdb', 'pudb', 'ipdb', 'pdb'):
-    try:
-        find_module(module)
+    if module_exists(module):
         vim.command('let g:pymode_breakpoint_cmd = "import %s; %s.set_trace()  # XXX BREAKPOINT"' % (module, module))
         break
-    except ImportError:
-        continue
-
 EOF
     endif
 

--- a/pymode/libs/pkg_resources/__init__.py
+++ b/pymode/libs/pkg_resources/__init__.py
@@ -2168,9 +2168,17 @@ def _handle_ns(packageName, path_item):
     importer = get_importer(path_item)
     if importer is None:
         return None
-    loader = importer.find_module(packageName)
+
+    if PY3:
+        loader = importer.find_spec(packageName)
+    else:
+        try:
+            loader = importer.find_module(packageName)
+        except ImportError:
+            loader = None
     if loader is None:
         return None
+
     module = sys.modules.get(packageName)
     if module is None:
         module = sys.modules[packageName] = types.ModuleType(packageName)


### PR DESCRIPTION
Just to tackle the operation-critical parts of the imp(ortlib) issue.
Alternative to https://github.com/python-mode/python-mode/pull/919.
I left out any fixes to logilab-common (which will be pretty complicated) as I can't even see if it is used  in any way by python-mode. :thinking: 
Tested locally with python 2.7.15 and 3.7.0.
---
This prevents obnoxious error messages each time a python file is opened in vim.
Breaks compatibility with python 3 versions < 3.4, however.