### PR TITLE
change find_spec to find_module

### DIFF
--- a/pymode/libs/pkg_resources/__init__.py
+++ b/pymode/libs/pkg_resources/__init__.py
@@ -2170,7 +2170,7 @@ def _handle_ns(packageName, path_item):
         return None
 
     if PY3:
-        loader = importer.find_spec(packageName)
+        loader = importer.find_module(packageName)
     else:
         try:
             loader = importer.find_module(packageName)


### PR DESCRIPTION
change find_spec to find_module to fix pylint error
see in [#958](https://github.com/python-mode/python-mode/issues/958)