### PR TITLE
fixed auto insert for rope complete

### DIFF
--- a/autoload/pymode/rope.vim
+++ b/autoload/pymode/rope.vim
@@ -15,14 +15,18 @@ endfunction
 
 fun! pymode#rope#complete(dot)
     if pumvisible()
-        return "\<C-n>"
+        if stridx('noselect', &completeopt) != -1
+            return "\<C-n>"
+        else
+            return ""
+        endif
     endif
     if a:dot
         PymodePython rope.complete(True)
     else
         PymodePython rope.complete()
     endif
-    return pumvisible() ? "\<C-p>\<Down>" : ""
+    return pumvisible() && stridx('noselect', &completeopt) != -1 ? "\<C-p>\<Down>" : ""
 endfunction
 
 fun! pymode#rope#complete_on_dot() "{{{

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -1,4 +1,4 @@
-*pymode.txt*     For Vim Version 8.0      Last change: 2017 November 20
+*pymode.txt*     For Vim Version 8.0      Last change: 2019 March 08
 
      ____  _  _  ____  _   _  _____  _  _     __  __  _____  ____  ____      ~
     (  _ \( \/ )(_  _)( )_( )(  _  )( \( )___(  \/  )(  _  )(  _ \( ___)     ~
@@ -483,6 +483,12 @@ your code. <C-X><C-O> and <C-P>/<C-N> works too.
 
 Autocompletion is also called by typing a period in |Insert| mode by default.
 
+If there's only one complete item, vim may be inserting it automatically
+instead of using a popup menu. If the complete item which inserted is not
+your wanted, you can roll it back use '<c-w>' in |Insert| mode or setup
+'completeopt' with `menuone` and `noinsert` in your vimrc. .e.g.
+>
+    set completeopt=menuone,noinsert
 
 Turn on code completion support in the plugin        *'g:pymode_rope_completion'*
 >

--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -94,7 +94,8 @@ def complete(dot=False):
     line = env.lines[row - 1]
     cline = line[:col] + p_prefix + line[col:]
     if cline != line:
-        env.curbuf[row - 1] = env.prepare_value(cline, dumps=False)
+        if 'noinsert' not in env.var('&completeopt'):
+            env.curbuf[row - 1] = env.prepare_value(cline, dumps=False)
     env.current.window.cursor = (row, col + len(p_prefix))
     env.run('complete', col - len(prefix) + len(p_prefix) + 1, proposals)
     return True


### PR DESCRIPTION
when define simple class like:

```python
class Foo:
    def __init__(self, name):
        self.{cursor_here}
```
it will auto insert first complete item and `__init__` will insert here. this is annoying for i just want code `self.name`.

the complete behaviour should respect the user's config of vim option &completeopt. In vim's docs, &completeopt has 'noselect' and 'noinsert' option, so it should worked here.

this pr related to #689 #782 