### PR TITLE
fixed find_module error for python 3.7 or newer

### DIFF
--- a/pymode/libs/pkg_resources/__init__.py
+++ b/pymode/libs/pkg_resources/__init__.py
@@ -2170,12 +2170,23 @@ def _handle_ns(packageName, path_item):
         return None
 
     if PY3:
+        # For python:
         # * since python 3.3, the `imp.find_module()` is deprecated
         # * `importlib.util.find_spec()` is new in python 3.4
-        # * in vim source, if compiled vim with python 3.7 or new, the vim
-        # python 3 interface will use `find_spec` instead of `find_module`
-        # and `load_module`. (note: this depends on the python which compiled
-        # with vim, not the python loaded by vim at runtime.)
+        #
+        # For vim:
+        # * if it compiled with python 3.7 or newer, then the module 'vim' will
+        # use `find_spec` instead of `find_module` and `load_module`.
+        # * if it compiled with feature `+python3/dyn`, vim can load a python
+        # dynamically. The loaded python maybe has a different version compared
+        # with the python used when compiling vim.
+        #
+        # As these reason, it's hard to say we should use `find_spec` or
+        # `find_module`, so here use try/except for the sake of clearness of
+        # the logic.
+        #
+        # As `find_module` is deprecated for newer python, we try `find_spec`
+        # first.
         try:
             loader = importer.find_spec(packageName)
         except AttributeError:

--- a/pymode/libs/pkg_resources/__init__.py
+++ b/pymode/libs/pkg_resources/__init__.py
@@ -2170,7 +2170,16 @@ def _handle_ns(packageName, path_item):
         return None
 
     if PY3:
-        loader = importer.find_module(packageName)
+        # * since python 3.3, the `imp.find_module()` is deprecated
+        # * `importlib.util.find_spec()` is new in python 3.4
+        # * in vim source, if compiled vim with python 3.7 or new, the vim
+        # python 3 interface will use `find_spec` instead of `find_module`
+        # and `load_module`. (note: this depends on the python which compiled
+        # with vim, not the python loaded by vim at runtime.)
+        try:
+            loader = importer.find_spec(packageName)
+        except AttributeError:
+            loader = importer.find_module(packageName)
     else:
         try:
             loader = importer.find_module(packageName)


### PR DESCRIPTION
when python version is 3.7 or newer, error occured when open python file

```
AttributeError: module 'vim' has no attribute 'find_module'
```
as comment in the code:

* since python 3.3, the `imp.find_module()` is deprecated
* `importlib.util.find_spec()` is new in python 3.4
* in vim source, if compiled vim with python 3.7 or new, the vim
 python 3 interface will use `find_spec` instead of `find_module`
 and `load_module`. (note: this depends on the python which compiled
 with vim, not the python loaded by vim at runtime.)

to sovle this, at first, python version detect maybe not worked since you can compile vim with python 3.7 and load python 3.6 at runtime, or in revese, second, we can detect module vim has `find_spec` or not, but then we should checking if we can import module vim or not ... to making it simple, i just used try..catch here.