### PR TITLE
Handle python imports in a pletora of setups

### DIFF
--- a/pymode/libs/pkg_resources/__init__.py
+++ b/pymode/libs/pkg_resources/__init__.py
@@ -46,6 +46,7 @@ except ImportError:
     import imp as _imp
 
 PY3 = sys.version_info > (3,)
+PY37 = sys.version_info > (3,7)
 PY2 = not PY3
 
 if PY3:
@@ -2169,13 +2170,23 @@ def _handle_ns(packageName, path_item):
     if importer is None:
         return None
 
-    if PY3:
-        loader = importer.find_module(packageName)
-    else:
-        try:
+    try:
+        if PY3:
+            # * since python 3.3, the `imp.find_module()` is deprecated.
+            # * `importlib.util.find_spec()` is new in python 3.4.
+            # * in vim source, if compiled vim with python 3.7 or new, the vim
+            # python 3 interface will use `find_spec` instead of `find_module`
+            # and `load_module`. (note: this depends on the python which
+            # compiled with vim, not the python loaded by vim at runtime.)
+            if PY37:
+                loader = importer.find_spec(packageName)
+            else:
+                loader = importer.find_module(packageName)
+        else:
             loader = importer.find_module(packageName)
-        except ImportError:
-            loader = None
+    except ImportError:
+        loader = None
+
     if loader is None:
         return None
 


### PR DESCRIPTION
There has been many changes in how python import modules across python
versions, specially in 3.3, 3.4 and 3.7.

This has caused many issues with modules importing in vim, and how vim
handles/implements imports from python also have caused many issues.

In python-mode we have tried many alternatives ways to fix this issues,
but they failed for many different conditions. This PR, based in the PR #985
proposed by @zcodes with some patches proposed by @nineKnight, intend to
resolve this issues definitively.

The main issue in our repo that track the problem solved by this commit
is the #972, there are lot's of comments and references over there.

Below are the comments from the original commit from @zcodes:

* since python 3.3, the `imp.find_module()` is deprecated

* `importlib.util.find_spec()` is new in python 3.4

* in vim source, if compiled vim with python 3.7 or new, the vim python 3
    interface will use `find_spec` instead of `find_module` and
    `load_module`. (note: this depends on the python which compiled with
    vim, not the python loaded by vim at runtime.)

I would like to thank @racterub, @joergsch, @zcodes, @nineKnight, @lalmeras,
@dbeniamine, and everyone else that helped with this issue.

Fix #972
Close #985
Close #955