### PR TITLE
fixed rope new project path error

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -235,6 +235,8 @@ def new():
         default = env.var('g:pymode_rope_project_root')
         if not default:
             default = env.var('getcwd()')
+        if sys.platform.startswith('win32'):
+            default = default.replace('\\', '/')
         root = env.var('input("Enter project root: ", "%s")' % default)
     ropefolder = env.var('g:pymode_rope_ropefolder')
     prj = project.Project(projectroot=root, ropefolder=ropefolder)


### PR DESCRIPTION
In windows, when vim without 'shellslash' options, the function getcwd()
return path string use `\` as directory separator. This will cause
python parse it error. To solve it, replace the `\` with `/`.

![error](https://user-images.githubusercontent.com/1469192/54103962-3e2c5d00-4409-11e9-8cc7-c04f9ad64d0c.png)
.