### PR TITLE
Move --recursive flag to --recurse-submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_install:
     - ./configure --with-features=huge --enable-multibyte --enable-python3interp=yes --with-python3-config-dir=/usr/lib/python3.5/config --enable-perlinterp=yes --enable-luainterp=yes --enable-gui=gtk2 --enable-cscope --prefix=/usr/local
     - sudo make && sudo make install
     - cd $ORIGINAL_FOLDER
-install: git clone --recursive https://github.com/python-mode/python-mode
+install: git clone --recurse-submodules https://github.com/python-mode/python-mode
 script: vim --version && cd ./tests && bash -x ./test.sh

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ hard coding 3rd party libraries into its codebase. Please issue the command:
 inside your python-mode folder.
 
 If you are a new user please clone the repos using the recursive flag:
-`git clone --recursive https://github.com/python-mode/python-mode`
+`git clone --recurse-submodules https://github.com/python-mode/python-mode`
 
 -------------------------------------------------------------------------------
 
@@ -88,14 +88,14 @@ As of vim8 there is an officially supported way of adding plugins. See `:tab
 help packages` in vim for details.
 
     cd ~/.vim/pack/python-mode/start
-    git clone --recursive https://github.com/python-mode/python-mode.git
+    git clone --recurse-submodules https://github.com/python-mode/python-mode.git
     cd python-mode
 
 ## Using pathogen
 
     cd ~/.vim
     mkdir -p bundle && cd bundle
-    git clone --recursive https://github.com/python-mode/python-mode.git
+    git clone --recurse-submodules https://github.com/python-mode/python-mode.git
 
 
 Enable [pathogen](https://github.com/tpope/vim-pathogen) in your `~/.vimrc`:
@@ -118,7 +118,7 @@ section of your `~/.vimrc`:
 
 ## Manually
 
-    % git clone --recursive https://github.com/python-mode/python-mode.git
+    % git clone --recurse-submodules https://github.com/python-mode/python-mode.git
     % cd python-mode
     % cp -R * ~/.vim
 


### PR DESCRIPTION
As per:
https://github.com/git/git/commit/bb62e0a99fcbb9ceb03502bf2168d2e57530214f
and
https://git-scm.com/docs/git-clone/

> Additionally the switch '--recurse' is removed from the Documentation as
> well as marked hidden in the options array, to streamline the options
> for submodules.  A simple '--recurse' doesn't convey what is being
> recursed, e.g. it could mean directories or trees (c.f. ls-tree) In a
> lot of other commands we already have '--recurse-submodules' to mean
> recursing into submodules, so advertise this spelling here as the
> genuine option.