### PR TITLE
Make Travis CI build status image link to latest build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![](https://travis-ci.org/python-mode/python-mode.svg?branch=develop)
+[![Build Status](https://travis-ci.org/python-mode/python-mode.svg?branch=develop)](https://travis-ci.org/python-mode/python-mode)
 
 ![](https://raw.github.com/python-mode/python-mode/develop/logo.png)
 # Python-mode, a Python IDE for Vim


### PR DESCRIPTION
Previously, the build status image just linked to the image, but this change makes the image link to the most recent build on travis-ci.org