### PR TITLE
Possibly fixing vim/python import machinery error

### DIFF
--- a/pymode/__init__.py
+++ b/pymode/__init__.py
@@ -4,7 +4,12 @@ from __future__ import absolute_import
 
 import sys
 import vim  # noqa
-
+try:
+    from importlib.machinery import PathFinder as _PathFinder
+    if not hasattr(vim, 'find_module'):
+        vim.find_module = _PathFinder.find_module
+except ImportError:
+    pass
 
 def auto():
     """Fix PEP8 erorrs in current buffer.


### PR DESCRIPTION
This is a possible fix for #972.

And it was based on https://github.com/pypa/setuptools/pull/1563#issuecomment-463801572