### PR TITLE
Change <C-c> to <leader>r to fix VIM8 incompatibility

### DIFF
--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -19,7 +19,7 @@ CONTENTS                                                        *pymode-contents
     2.4 Vim motion................................................|pymode-motion|
     2.5 Show documentation.................................|pymode-documentation|
     2.6 Support virtualenv....................................|pymode-virtualenv|
-    2.7 Run code.....................................................|pymode-run|
+    2.7 Execute code.................................................|pymode-run|
     2.8 Breakpoints..........................................|pymode-breakpoints|
 3. Code checking....................................................|pymode-lint|
     3.1 Code checkers options...............................|pymode-lint-options|
@@ -57,7 +57,7 @@ Features:                                                       *pymode-features
 - Support Python version 2.6+ and 3.2+
 - Syntax highlighting
 - Virtualenv support
-- Run python code (``<leader>r``)
+- Run python code (``<leader>e``)
 - Add/remove breakpoints (``<leader>b``)
 - Improved Python indentation
 - Python folding
@@ -69,7 +69,7 @@ Features:                                                       *pymode-features
 - Search in python documentation (``K``)
 - Code refactoring <rope refactoring library> (rope_)
 - Strong code completion (rope_)
-- Go to definition (``<C-c>g`` for `:RopeGotoDefinition`)
+- Go to definition (``<leader>rg`` for `:RopeGotoDefinition`)
 - And more, more ...
 
 
@@ -244,11 +244,11 @@ Set path to virtualenv manually                      *'g:pymode_virtualenv_path'
     let g:pymode_virtualenv_path = $VIRTUAL_ENV
 
 -------------------------------------------------------------------------------
-2.7 Run code ~
+2.7 Execute code ~
                                                                      *pymode-run*
 
 Commands:
-*:PymodeRun* -- Run current buffer or selection
+*:PymodeRun* -- Execute current buffer or selection
 
 Turn on the run code script                                      *'g:pymode_run'*
 >
@@ -256,7 +256,7 @@ Turn on the run code script                                      *'g:pymode_run'
 
 Binds keys to run python code                               *'g:pymode_run_bind'*
 >
-    let g:pymode_run_bind = '<leader>r'
+    let g:pymode_run_bind = '<leader>e'
 
 -------------------------------------------------------------------------------
 2.8 Breakpoints ~
@@ -411,7 +411,7 @@ Commands:
 
 Turn on the rope script                                         *'g:pymode_rope'*
 >
-    let g:pymode_rope = 1
+    let g:pymode_rope = 0
 
 .ropeproject Folder ~
                                                                    *.ropeproject*
@@ -467,7 +467,7 @@ Show documentation for element under cursor ~
 Show documentation for object under cursor.       *'g:pymode_rope_show_doc_bind'*
 Leave empty to disable the key binding.
 >
-    let g:pymode_rope_show_doc_bind = '<C-c>d'
+    let g:pymode_rope_show_doc_bind = '<leader>rd'
 
 Regenerate project cache on every save (if file has been modified)
 >
@@ -525,7 +525,7 @@ By default when you press *<C-C>g* on any object in your code you will be moved
 to definition.
 Leave empty for disable key binding.       *'g:pymode_rope_goto_definition_bind'*
 >
-    let g:pymode_rope_goto_definition_bind = '<C-c>g'
+    let g:pymode_rope_goto_definition_bind = '<leader>rg'
 
 Command for open window when definition has been found
 Values are (`e`, `new`, `vnew`)                   *'g:pymode_rope_goto_definition_cmd'*
@@ -544,7 +544,7 @@ variables and keyword arguments.
 Keymap for rename method/function/class/variables under cursor
                                                     *'g:pymode_rope_rename_bind'*
 >
-    let g:pymode_rope_rename_bind = '<C-c>rr'
+    let g:pymode_rope_rename_bind = '<leader>rrr'
 
 
 Rename a current module/package ~
@@ -553,7 +553,7 @@ Rename a current module/package ~
 
 Keymap for rename current module             *'g:pymode_rope_rename_module_bind'*
 >
-    let g:pymode_rope_rename_module_bind = '<C-c>r1r'
+    let g:pymode_rope_rename_module_bind = '<leader>rr1r'
 
 
 Imports ~
@@ -564,12 +564,12 @@ Organize imports sorts imports, too. It does that according to PEP8. Unused
 imports will be dropped.
 Keymap                                    *'g:pymode_rope_organize_imports_bind'*
 >
-    let g:pymode_rope_organize_imports_bind = '<C-c>ro'
+    let g:pymode_rope_organize_imports_bind = '<leader>rro'
 
 Insert import for current word under cursor     *'g:pymode_rope_autoimport_bind'*
 Should be enabled |'g:pymode_rope_autoimport'|
 >
-    let g:pymode_rope_autoimport_bind = '<C-c>ra'
+    let g:pymode_rope_autoimport_bind = '<leader>rra'
 
 
 Convert module to package ~
@@ -579,7 +579,7 @@ Convert module to package ~
 
 Keybinding:
 >
-    let g:pymode_rope_module_to_package_bind = '<C-c>r1p'
+    let g:pymode_rope_module_to_package_bind = '<leader>rr1p'
 
 
 Extract method/variable ~
@@ -590,8 +590,8 @@ Extract method/variable from selected lines.
                                             *'g:pymode_rope_extract_method_bind'*
                                           *'g:pymode_rope_extract_variable_bind'*
 >
-    let g:pymode_rope_extract_method_bind = '<C-c>rm'
-    let g:pymode_rope_extract_variable_bind = '<C-c>rl'
+    let g:pymode_rope_extract_method_bind = '<leader>rrm'
+    let g:pymode_rope_extract_variable_bind = '<leader>rrl'
 
 
 Use function ~
@@ -600,7 +600,7 @@ Use function ~
 It tries to find the places in which a function can be used and changes the
 code to call it instead.
 >
-    let g:pymode_rope_use_function_bind = '<C-c>ru'
+    let g:pymode_rope_use_function_bind = '<leader>rru'
 
 
 Move method/fields ~
@@ -612,11 +612,11 @@ attributes. The old method will call the new method. If you want to change all
 of the occurrences of the old method to use the new method you can inline it
 afterwards.
 >
-    let g:pymode_rope_move_bind = '<C-c>rv'
+    let g:pymode_rope_move_bind = '<leader>rrv'
 
 Change function signature ~
 >
-    let g:pymode_rope_change_signature_bind = '<C-c>rs'
+    let g:pymode_rope_change_signature_bind = '<leader>rrs'
 
 
 -------------------------------------------------------------------------------

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -93,7 +93,7 @@ call pymode#default('g:pymode_virtualenv_enabled', '')
 call pymode#default('g:pymode_run', 1)
 
 " Key's map for run python code
-call pymode#default('g:pymode_run_bind', '<leader>r')
+call pymode#default('g:pymode_run_bind', '<leader>e')
 
 " }}}
 
@@ -210,7 +210,7 @@ if g:pymode_rope
     call pymode#default('g:pymode_rope_autoimport_modules', ['os', 'shutil', 'datetime'])
 
     " Bind keys to autoimport module for object under cursor
-    call pymode#default('g:pymode_rope_autoimport_bind', '<C-c>ra')
+    call pymode#default('g:pymode_rope_autoimport_bind', '<leader>rra')
 
     " Automatic completion on dot
     call pymode#default('g:pymode_rope_complete_on_dot', 1)
@@ -219,56 +219,56 @@ if g:pymode_rope
     call pymode#default('g:pymode_rope_completion_bind', '<C-Space>')
 
     " Bind keys for goto definition (leave empty for disable)
-    call pymode#default('g:pymode_rope_goto_definition_bind', '<C-c>g')
+    call pymode#default('g:pymode_rope_goto_definition_bind', '<leader>rg')
 
     " set command for open definition (e, new, vnew)
     call pymode#default('g:pymode_rope_goto_definition_cmd', 'new')
 
     " Bind keys for show documentation (leave empty for disable)
-    call pymode#default('g:pymode_rope_show_doc_bind', '<C-c>d')
+    call pymode#default('g:pymode_rope_show_doc_bind', '<leader>rd')
 
     " Bind keys for find occurencies (leave empty for disable)
-    call pymode#default('g:pymode_rope_find_it_bind', '<C-c>f')
+    call pymode#default('g:pymode_rope_find_it_bind', '<leader>rf')
 
     " Bind keys for organize imports (leave empty for disable)
-    call pymode#default('g:pymode_rope_organize_imports_bind', '<C-c>ro')
+    call pymode#default('g:pymode_rope_organize_imports_bind', '<leader>rro')
 
     " Bind keys for rename variable/method/class in the project (leave empty for disable)
-    call pymode#default('g:pymode_rope_rename_bind', '<C-c>rr')
+    call pymode#default('g:pymode_rope_rename_bind', '<leader>rrr')
 
     " Bind keys for rename module
-    call pymode#default('g:pymode_rope_rename_module_bind', '<C-c>r1r')
+    call pymode#default('g:pymode_rope_rename_module_bind', '<leader>rr1r')
 
     " Bind keys for convert module to package
-    call pymode#default('g:pymode_rope_module_to_package_bind', '<C-c>r1p')
+    call pymode#default('g:pymode_rope_module_to_package_bind', '<leader>rr1p')
 
     " Creates a new function or method (depending on the context) from the selected lines
-    call pymode#default('g:pymode_rope_extract_method_bind', '<C-c>rm')
+    call pymode#default('g:pymode_rope_extract_method_bind', '<leader>rrm')
 
     " Creates a variable from the selected lines
-    call pymode#default('g:pymode_rope_extract_variable_bind', '<C-c>rl')
+    call pymode#default('g:pymode_rope_extract_variable_bind', '<leader>rrl')
 
     " Inline refactoring
-    call pymode#default('g:pymode_rope_inline_bind', '<C-c>ri')
+    call pymode#default('g:pymode_rope_inline_bind', '<leader>rri')
 
     " Move refactoring
-    call pymode#default('g:pymode_rope_move_bind', '<C-c>rv')
+    call pymode#default('g:pymode_rope_move_bind', '<leader>rrv')
 
     " Generate function
-    call pymode#default('g:pymode_rope_generate_function_bind', '<C-c>rnf')
+    call pymode#default('g:pymode_rope_generate_function_bind', '<leader>rrnf')
 
     " Generate class
-    call pymode#default('g:pymode_rope_generate_class_bind', '<C-c>rnc')
+    call pymode#default('g:pymode_rope_generate_class_bind', '<leader>rrnc')
 
     " Generate package
-    call pymode#default('g:pymode_rope_generate_package_bind', '<C-c>rnp')
+    call pymode#default('g:pymode_rope_generate_package_bind', '<leader>rrnp')
 
     " Change signature
-    call pymode#default('g:pymode_rope_change_signature_bind', '<C-c>rs')
+    call pymode#default('g:pymode_rope_change_signature_bind', '<leader>rrs')
 
     " Tries to find the places in which a function can be used and changes the
     " code to call it instead
-    call pymode#default('g:pymode_rope_use_function_bind', '<C-c>ru')
+    call pymode#default('g:pymode_rope_use_function_bind', '<leader>rru')
 
     " Regenerate project cache on every save
     call pymode#default('g:pymode_rope_regenerate_on_write', 1)

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ The plugin contains all you need to develop python applications in Vim.
 * Support Python version 2.6+ and 3.2+
 * Syntax highlighting
 * Virtualenv support
-* Run python code (`<leader>r`)
+* Execute python code (`<leader>e`)
 * Add/remove breakpoints (`<leader>b`)
 * Improved Python indentation
 * Python motions and operators (`]]`, `3[[`, `]]M`, `vaC`, `viM`,
@@ -64,7 +64,7 @@ The plugin contains all you need to develop python applications in Vim.
 * Search in python documentation (`<leader>K`)
 * Code refactoring
 * Intellisense code-completion
-* Go to definition (`<C-c>g`)
+* Go to definition (`<leader>rg`)
 * And more, more ...
 
 See a screencast here: <http://www.youtube.com/watch?v=67OZNp9Z0CQ>.


### PR DESCRIPTION
Following pull request contain 3 changes:
1. `<C-c>` mapping has been changed to `<leader>r` (r for Rope) in all mappings
2. `<leader>r` mapping for python run code has been chaged to`<leader>e` (Run -> Execute)
3. fixed Rope default status to disabled in documentation

This will fix incompatibilities with VIM8

This is my first ever pull request and first ever fork, so sorry if I made all this wrong...
 