### PR TITLE
Fix text objects to be line-wise rather than character-wise operator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Contributors:
 * Kurtis Rader (https://github.com/krader1961);
 * Lawrence Akka (https://github.com/lawrenceakka);
 * lee (https://github.com/loyalpartner);
+* Lie Ryan (https://github.com/lieryan/);
 * Lowe Thiderman (http://github.com/thiderman);
 * Martin Brochhaus (http://github.com/mbrochh);
 * Matt Dodge (https://github.com/mattdodge);

--- a/autoload/pymode/motion.vim
+++ b/autoload/pymode/motion.vim
@@ -51,7 +51,7 @@ fun! pymode#motion#select(first_pattern, second_pattern, inner) "{{{
         endif
 
         call cursor(snum, 1)
-        normal! v
+        normal! V
         call cursor(enum, len(getline(enum)))
     endif
 endfunction "}}}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,6 +20,7 @@ declare -a TEST_ARRAY=(
     "./test_bash/test_autopep8.sh"
     "./test_bash/test_autocommands.sh"
     "./test_bash/test_folding.sh"
+    "./test_bash/test_textobject.sh"
     )
 ## now loop through the above array
 set +e

--- a/tests/test_bash/test_autocommands.sh
+++ b/tests/test_bash/test_autocommands.sh
@@ -20,10 +20,10 @@ set +e
 for ONE_PYMODE_COMMANDS_TEST in "${TEST_PYMODE_COMMANDS_ARRAY[@]}"
 do
     echo "Starting test: $0:$ONE_PYMODE_COMMANDS_TEST" >> $VIM_OUTPUT_FILE
-    RETURN_CODE=$(vim -i NONE -u $VIM_TEST_VIMRC -c "source $ONE_PYMODE_COMMANDS_TEST" $VIM_DISPOSABLE_PYFILE > /dev/null 2>&1)
+    RETURN_CODE=$(vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source $ONE_PYMODE_COMMANDS_TEST" $VIM_DISPOSABLE_PYFILE > /dev/null 2>&1)
 
     ### Enable the following to execute one test at a time.
-    ### FOR PINPOINT TESTING ### vim -i NONE -u $VIM_TEST_VIMRC -c "source $ONE_PYMODE_COMMANDS_TEST" $VIM_DISPOSABLE_PYFILE
+    ### FOR PINPOINT TESTING ### vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source $ONE_PYMODE_COMMANDS_TEST" $VIM_DISPOSABLE_PYFILE
     ### FOR PINPOINT TESTING ### exit 1
 
     RETURN_CODE=$?

--- a/tests/test_bash/test_autopep8.sh
+++ b/tests/test_bash/test_autopep8.sh
@@ -2,7 +2,7 @@
 
 # Source file.
 set +e
-RETURN_CODE=$(vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/autopep8.vim" $VIM_DISPOSABLE_PYFILE > /dev/null 2>&1)
+RETURN_CODE=$(vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/autopep8.vim" $VIM_DISPOSABLE_PYFILE > /dev/null 2>&1)
 RETURN_CODE=$?
 set -e
 exit $RETURN_CODE

--- a/tests/test_bash/test_folding.sh
+++ b/tests/test_bash/test_folding.sh
@@ -5,17 +5,17 @@
 # Source file.
 set +e
 source ./test_helpers_bash/test_prepare_between_tests.sh
-vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding1.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
+vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding1.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
 R1=$?
 source ./test_helpers_bash/test_prepare_between_tests.sh
-vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding2.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
+vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding2.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
 R2=$?
 source ./test_helpers_bash/test_prepare_between_tests.sh
 # TODO: enable folding3.vim script back.
-# vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding3.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
+# vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding3.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
 # R3=$?
 source ./test_helpers_bash/test_prepare_between_tests.sh
-vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding4.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
+vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/folding4.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
 R4=$?
 set -e
 

--- a/tests/test_bash/test_pymodelint.sh
+++ b/tests/test_bash/test_pymodelint.sh
@@ -5,8 +5,8 @@
 
 # Source file.
 set +e
-vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/pymodelint.vim" $VIM_DISPOSABLE_PYFILE
-# RETURN_CODE=$(vim -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/pymodeversion.vim" $VIM_DISPOSABLE_PYFILE > /dev/null 2>&1)
+vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/pymodelint.vim" $VIM_DISPOSABLE_PYFILE
+# RETURN_CODE=$(vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/pymodeversion.vim" $VIM_DISPOSABLE_PYFILE > /dev/null 2>&1)
 # RETURN_CODE=$?
 set -e
 # exit $RETURN_CODE

--- a/tests/test_bash/test_textobject.sh
+++ b/tests/test_bash/test_textobject.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Source file.
+set +e
+source ./test_helpers_bash/test_prepare_between_tests.sh
+vim --clean -i NONE -u $VIM_TEST_VIMRC -c "source ./test_procedures_vimscript/textobject.vim" $VIM_DISPOSABLE_PYFILE > /dev/null
+R1=$?
+set -e
+
+if [[ "$R1" -ne 0 ]]
+then
+    exit 1
+fi
+
+# vim: set fileformat=unix filetype=sh wrap tw=0 :

--- a/tests/test_procedures_vimscript/textobject.vim
+++ b/tests/test_procedures_vimscript/textobject.vim
@@ -1,0 +1,29 @@
+" Load sample python file.
+" With 'def'.
+execute "normal! idef func1():\<CR>    a = 1\<CR>"
+execute "normal! idef func2():\<CR>    b = 2"
+normal 3ggdaMggf(P
+
+" Assert changes.
+let content=getline('^', '$')
+call assert_true(content == ['def func2():', '    b = 2', 'def func1():', '    a = 1'])
+
+
+" Clean file.
+%delete
+
+" With 'class'.
+execute "normal! iclass Class1():\<CR>    a = 1\<CR>"
+execute "normal! iclass Class2():\<CR>    b = 2\<CR>"
+normal 3ggdaCggf(P
+
+" Assert changes.
+let content=getline('^', '$')
+call assert_true(content == ['class Class2():', '    b = 2', '', 'class Class1():', '    a = 1'])
+
+
+if len(v:errors) > 0
+    cquit!
+else
+    quit!
+endif


### PR DESCRIPTION
The text objects command like `daC` and `diM` previously worked using character-wise selection. This is rarely what the user want, as it means that pasting with (`p`) does not work if your cursor is not on column 0 and paste with reindent (`]p`) does not work at all.

This PR changes these text objects to be line-wise, which aligns it with other similar builtin motion commands like dap/dip (delete a/inner paragraph).

All tests seems to pass, though I'm not quite sure how to add a new test for this.