### PR TITLE
Experimental - running PymodeRopeRegenerate in background

### DIFF
--- a/pymode/environment.py
+++ b/pymode/environment.py
@@ -223,6 +223,9 @@ class VimPymodeEnviroment(object):
         env.debug('Get offset', base or None, row, col, offset)
         return source, offset
 
+    def async_call(self, func, *args, **kwargs):
+        vim.async_call(func, *args, **kwargs)
+
     @staticmethod
     def goto_line(line):
         """Go to line."""

--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -415,10 +415,11 @@ class RopeContext(object):
         modules = self.options.get('autoimport_modules', [])
 
         def _update_cache(importer, modules=None):
-            importer.generate_cache(task_handle=progress.handle)
-            if modules:
-                importer.generate_modules_cache(modules)
-            importer.project.sync()
+            with progress.context(self):
+                importer.generate_cache(task_handle=progress.handle)
+                if modules:
+                    importer.generate_modules_cache(modules)
+                importer.project.sync()
         progress = BackgroundProgressHandler('Regenerate autoimport cache')
         progress.run_in_background(lambda: _update_cache(self.importer, modules))
 


### PR DESCRIPTION
Ok, this is a bit of a wild experiment. This is currently only for neovim.

This branch offloads slow rope tasks such as :PymodeRopeRegenerate in a background thread. This means that the editor remains responsive while rope is loading, which can take a while in larger projects. Completion and refactoring may not be available until the cache regeneration is actually completed.

The background task handler currently only works in neovim. In regular vim, it currently uses a dummy task handler that still runs rope in foreground so the editor still locks up.

Currently, there are a few errors/exceptions that sometimes pops up in message if you try to use completion/refactoring while the cache is still building. This is ugly and makes nvim looks somewhat crashy, spewing out errors, but it doesn't affect functionality and I already find it very useful to not have the editor locks up unexpectedly.