### PR TITLE
Issue 1045 imp module deprecation error

### DIFF
--- a/autoload/pymode/breakpoint.vim
+++ b/autoload/pymode/breakpoint.vim
@@ -15,11 +15,11 @@ fun! pymode#breakpoint#init() "{{{
 
         PymodePython << EOF
 
-from imp import find_module
+from importlib import import_module
 
 for module in ('wdb', 'pudb', 'ipdb'):
     try:
-        find_module(module)
+        import_module(module)
         vim.command('let g:pymode_breakpoint_cmd = "import %s; %s.set_trace()  # XXX BREAKPOINT"' % (module, module))
         break
     except ImportError:


### PR DESCRIPTION
## WHAT:
Change importlib for imp

## WHY:
In the vim command there is an imp module is used, which has been
deprecated. The vim command would through the deprication warning,
    stoping function in vim without user intervention.