### PR TITLE
Add option g:pymode_indent_hanging_width for different hanging indentation width

### DIFF
--- a/autoload/pymode/indent.vim
+++ b/autoload/pymode/indent.vim
@@ -24,7 +24,9 @@ function! pymode#indent#get_indent(lnum)
             if closing_paren
                 return indent(parlnum)
             else
-                return indent(parlnum) + &shiftwidth
+                let l:indent_width = (g:pymode_indent_hanging_width > 0 ?
+                            \ g:pymode_indent_hanging_width : &shiftwidth)
+                return indent(parlnum) + l:indent_width
             endif
         else
             return parcol

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -170,6 +170,16 @@ Enable pymode indentation                                     *'g:pymode_indent'
 >
     let g:pymode_indent = 1
 
+
+Customization:
+
+Hanging indent size after an open parenthesis or bracket (but nothing after the
+parenthesis), when vertical alignment is not used. Defaults to `&shiftwidth`.
+                                                *'g:pymode_indent_hanging_width'*
+>
+    let g:pymode_indent_hanging_width = &shiftwidth
+    let g:pymode_indent_hanging_width = 4
+
 -------------------------------------------------------------------------------
 2.3 Python folding ~
                                                                  *pymode-folding*

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -38,6 +38,9 @@ call pymode#default('g:pymode_doc_bind', 'K')
 " Enable/Disable pymode PEP8 indentation
 call pymode#default("g:pymode_indent", 1)
 
+" Customize hanging indent size different than &shiftwidth
+call pymode#default("g:pymode_indent_hanging_width", -1)
+
 " TODO: currently folding suffers from a bad performance and incorrect
 " implementation. This feature should be considered experimental.
 " Enable/disable pymode folding for pyfiles.


### PR DESCRIPTION
This is an option for hanging indent size after an open parenthesis
in line continuations. It defaults to `&shiftwidth` but can be assigned
a different value.

For example, hanging indent size can be set to 4 (even if the tabsize
or shiftwidth is not 4) as per [Google Python Style Guide (3.4. Indentation)](https://google.github.io/styleguide/pyguide.html#34-indentation).

Example:

```python
if True:
  pass     # 2 spaces are used for indentation

# 4-space hanging indent; nothing on first line
foo = long_function_name(
    var_one, var_two, var_three,
    var_four)
```