### PR TITLE
Fix Global and Module MoveRefactoring

### DIFF
--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -613,14 +613,24 @@ code to call it instead.
     let g:pymode_rope_use_function_bind = '<C-c>ru'
 
 
-Move method/fields ~
+Move refactoring ~
                                                                *pymode-rope-move*
+
+Moving method/fields
 
 It happens when you perform move refactoring on a method of a class. In this
 refactoring, a method of a class is moved to the class of one of its
 attributes. The old method will call the new method. If you want to change all
 of the occurrences of the old method to use the new method you can inline it
 afterwards.
+
+Moving global variable/class/function into another module
+
+It happens when you perform move refactoring on global variable/class/function.
+In this refactoring, the object being refactored will be moved to a destination
+module. All references to the object being moved will be updated to point to
+the new location.
+
 >
     let g:pymode_rope_move_bind = '<C-c>rv'
 

--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -631,6 +631,13 @@ In this refactoring, the object being refactored will be moved to a destination
 module. All references to the object being moved will be updated to point to
 the new location.
 
+Moving module variable/class/function into a package
+
+It happens when you perform move refactoring on a name referencing a module.
+In this refactoring, the module being refactored will be moved to a destination
+package. All references to the object being moved will be updated to point to
+the new location.
+
 >
     let g:pymode_rope_move_bind = '<C-c>rv'
 

--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -701,6 +701,15 @@ class MoveRefactoring(Refactoring):
             offset = None
         return move.create_move(ctx.project, ctx.resource, offset)
 
+    @staticmethod
+    def get_changes(refactor, input_str, in_hierarchy=False):
+        with RopeContext() as ctx:
+            if isinstance(refactor, (move.MoveGlobal, move.MoveModule)):
+                dest = ctx.project.pycore.find_module(input_str)
+            else:
+                dest = input_str
+            return super(MoveRefactoring, MoveRefactoring).get_changes(refactor, dest, in_hierarchy=in_hierarchy)
+
 
 class ChangeSignatureRefactoring(Refactoring):
 


### PR DESCRIPTION
Global and Module Move refactoring requires that `dest` be a rope
module, while Method Move refactoring requires that `dest` be an
attribute name.

Previously, Global Move refactoring errors out with 

    [Pymode]: error: Unhandled exception in Pymode: 'str' object has no attribute 'exists'

And Module Move refactoring errors out with:

    [Pymode]: error: Unhandled exception in Pymode: 'str' object has no attribute 'is_folder'


To perform Global Move refactoring:

1. create a file mod1.py and mod2.py containing

```
# mod1.py
import mod2
myvar = 1
def myfunc():
    pass
class MyClass:
    pass
```

```
# mod2.py
# just empty
```

2. To perform Global Move refactoring, point vim cursor to `myvar`/`myfunc`/`MyClass`, then press `<C-c>rv`
3. When the destination prompt appears, type "mod2" as destination

To perform a Module Move refactoring:

1. create a file mod1.py and pkg/mod2.py containing

```
# mod1.py
import mod2
myvar = 1
def myfunc():
    print(myvar)
    print(MyClass)
class MyClass:
    pass
```

```
# pgk/__init__.py
# just empty
```

```
# mod2.py
# just empty
```

2. To perform Module Move refactoring, point vim cursor to `mod2`, then press `<C-c>rv`
3. When the destination prompt appears.. Type "pkg" as destination.