### PR TITLE
Don't display in_hierarchy options that are not relevant to the current refactoring operation

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -497,8 +497,6 @@ class Refactoring(object): # noqa
         return [
             'perform',
             'preview',
-            'perform in class hierarchy',
-            'preview in class hierarchy',
         ]
 
     @staticmethod
@@ -554,6 +552,14 @@ class RenameRefactoring(Refactoring):
             return False
 
         return newname
+
+    def get_code_actions(self):
+        return [
+            'perform',
+            'preview',
+            'perform in class hierarchy',
+            'preview in class hierarchy',
+        ]
 
     @staticmethod
     def get_changes(refactor, input_str, in_hierarchy=False):
@@ -710,6 +716,14 @@ class MoveRefactoring(Refactoring):
             offset = None
         return move.create_move(ctx.project, ctx.resource, offset)
 
+    def get_code_actions(self):
+        return [
+            'perform',
+            'preview',
+            'perform in class hierarchy',
+            'preview in class hierarchy',
+        ]
+
 
 class ChangeSignatureRefactoring(Refactoring):
 
@@ -736,6 +750,14 @@ class ChangeSignatureRefactoring(Refactoring):
         _, offset = env.get_offset_params()
         return change_signature.ChangeSignature(
             ctx.project, ctx.resource, offset)
+
+    def get_code_actions(self):
+        return [
+            'perform',
+            'preview',
+            'perform in class hierarchy',
+            'preview in class hierarchy',
+        ]
 
     def get_changes(self, refactor, input_string, in_hierarchy=False):
         """ Function description.

--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -463,10 +463,11 @@ class Refactoring(object): # noqa
                 if not input_str:
                     return False
 
+                code_actions = self.get_code_actions()
                 action = env.user_input_choices(
-                    'Choose what to do:', 'perform', 'preview',
-                    'perform in class hierarchy',
-                    'preview in class hierarchy')
+                    'Choose what to do:',
+                    *code_actions,
+                )
 
                 in_hierarchy = action.endswith("in class hierarchy")
 
@@ -491,6 +492,14 @@ class Refactoring(object): # noqa
 
             except Exception as e: # noqa
                 env.error('Unhandled exception in Pymode: %s' % e)
+
+    def get_code_actions(self):
+        return [
+            'perform',
+            'preview',
+            'perform in class hierarchy',
+            'preview in class hierarchy',
+        ]
 
     @staticmethod
     def get_refactor(ctx):


### PR DESCRIPTION
Currently, when doing a refactoring operation, python-mode often display this four options:

```
[Pymode] Choose what to do:
1. perform
2. preview
3. perform in class hierarchy
4. preview in class hierarchy
Type number and <Enter> or click with the mouse (q or empty cancels): 
```

In many of the operations, 3 and 4 doesn't really do anything different than 1 and 2 and it's rather difficult to remember which operations you can actually do in_hierarchy with and which ones doesn't. 

With this PR, we don't show these extraneous operations when they are not relevant for the current refactoring operation. 

```
[Pymode] Choose what to do:
1. perform
2. preview
Type number and <Enter> or click with the mouse (q or empty cancels): 
```