### PR TITLE
Fix PathFinder.find_module AttributeError for Python 3.12

### DIFF
--- a/pymode/__init__.py
+++ b/pymode/__init__.py
@@ -6,7 +6,13 @@ from importlib.machinery import PathFinder as _PathFinder
 import vim  # noqa
 
 if not hasattr(vim, 'find_module'):
-    vim.find_module = _PathFinder.find_module
+    try:
+        vim.find_module = _PathFinder.find_module  # deprecated
+    except AttributeError:
+        def _find_module(package_name):
+            spec = _PathFinder.find_spec(package_name)
+            return spec.loader if spec else None
+        vim.find_module = _find_module
 
 
 def auto():


### PR DESCRIPTION
PathFinder.find_module() has been deprecated since Python 3.4 in favor of find_spec(), and it's finally removed in Python 3.12. This line will throw an AttributeError which makes pymode completely unusable with python 3.12.

It was a hacky workaround introduced in #1028. Maybe we can completely remove this workaround because it's 4 years ago and the minimum supported python version is now 3.6+.

I'm not sure if we can completely remove this monkey-patching at this point because I cannot guess where `vim.find_module` is ever used, but I'll leave it as the most compatible fallback.

Ref:

- #972 (bug)
- PR #1028 has introduced this monkey-patch hack (/cc @diraol)
- https://github.com/pypa/setuptools/pull/1563#issuecomment-463801572
