### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       with:
         submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
         bash scripts/cicd/run_vader_tests_direct.sh
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
       if: always()
       with:
         name: test-results-${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
           results/
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 #v3
       with:
         file: ./coverage.xml
         flags: python-${{ matrix.python-version }}
@@ -59,12 +59,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       with:
         submodules: recursive
 
     - name: Download all test results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
       with:
         path: test-results-artifacts
         pattern: test-results-*


### PR DESCRIPTION
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds.

## Why pin to commit SHAs?

Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `codecov/codecov-action` from `v3` to `ab904c4` in `.github/workflows/test.yml`
- Pinned `actions/download-artifact` from `v4` to `d3f86a1` in `.github/workflows/test.yml`
- Pinned `actions/upload-artifact` from `v4` to `ea165f8` in `.github/workflows/test.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test.yml`
- Pinned `actions/setup-python` from `v5` to `a26af69` in `.github/workflows/test.yml`
